### PR TITLE
Add slugs for Unit and Resource

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ django-image-cropping
 easy_thumbnails
 -e git+https://github.com/City-of-Helsinki/django-helusers.git#egg=django-helusers
 django-allauth
+django-autoslug==1.9.3

--- a/resources/migrations/0015_auto_20151028_1648.py
+++ b/resources/migrations/0015_auto_20151028_1648.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import autoslug.fields
+import resources.models.utils
+from autoslug.utils import get_prepopulated_value
+
+
+def backwards(apps, schema_editor):
+    pass
+
+
+def forwards(apps, schema_editor):
+    """
+    Add slugs to existing Units and Resources.
+    """
+    Resource = apps.get_model('resources', 'Resource')
+    for resource in Resource.objects.filter(slug=''):
+        resource.slug = get_prepopulated_value(resource._meta.get_field('slug'), resource)
+        resource.save()
+    Unit = apps.get_model('resources', 'Unit')
+    for unit in Unit.objects.filter(slug=''):
+        unit.slug = get_prepopulated_value(unit._meta.get_field('slug'), unit)
+        unit.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resources', '0014_add_resource_image'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='resource',
+            name='slug',
+            field=autoslug.fields.AutoSlugField(editable=False, populate_from=resources.models.utils.get_translated_name, blank=True),
+        ),
+        migrations.AddField(
+            model_name='unit',
+            name='slug',
+            field=autoslug.fields.AutoSlugField(editable=False, populate_from=resources.models.utils.get_translated_name, blank=True),
+        ),
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/resources/migrations/0016_auto_20151028_1653.py
+++ b/resources/migrations/0016_auto_20151028_1653.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import autoslug.fields
+import resources.models.utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resources', '0015_auto_20151028_1648'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='resource',
+            name='slug',
+            field=autoslug.fields.AutoSlugField(editable=False, unique=True, populate_from=resources.models.utils.get_translated_name),
+        ),
+        migrations.AlterField(
+            model_name='unit',
+            name='slug',
+            field=autoslug.fields.AutoSlugField(editable=False, unique=True, populate_from=resources.models.utils.get_translated_name),
+        ),
+    ]

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -12,11 +12,12 @@ from django.utils.six import BytesIO
 from django.utils.translation import ugettext_lazy as _
 from image_cropping import ImageRatioField
 from PIL import Image
+from autoslug import AutoSlugField
 
 from resources.errors import InvalidImage
 
 from .base import AutoIdentifiedModel, ModifiableModel
-from .utils import get_translated
+from .utils import get_translated, get_translated_name
 
 
 class ResourceType(ModifiableModel, AutoIdentifiedModel):
@@ -83,6 +84,8 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
     min_period = models.DurationField(verbose_name=_('Minimum reservation time'),
                                       default=datetime.timedelta(minutes=30))
     max_period = models.DurationField(verbose_name=_('Maximum reservation time'), null=True, blank=True)
+
+    slug = AutoSlugField(populate_from=get_translated_name, unique=True)
 
     class Meta:
         verbose_name = _("resource")

--- a/resources/models/unit.py
+++ b/resources/models/unit.py
@@ -6,10 +6,10 @@ from django.conf import settings
 from django.contrib.gis.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
+from autoslug import AutoSlugField
 
 from .base import AutoIdentifiedModel, ModifiableModel
-from .utils import get_translated
-
+from .utils import get_translated, get_translated_name
 
 class Unit(ModifiableModel, AutoIdentifiedModel):
     id = models.CharField(primary_key=True, max_length=50)
@@ -34,6 +34,8 @@ class Unit(ModifiableModel, AutoIdentifiedModel):
                                   null=True, blank=True)
     picture_caption = models.CharField(verbose_name=_('Picture caption'), max_length=200,
                                        null=True, blank=True)
+
+    slug = AutoSlugField(populate_from=get_translated_name, unique=True)
 
     class Meta:
         verbose_name = _("unit")

--- a/resources/models/utils.py
+++ b/resources/models/utils.py
@@ -36,6 +36,11 @@ def get_translated(obj, attr):
     return val
 
 
+# Needed for slug fields populating
+def get_translated_name(obj):
+    return get_translated(obj, 'name')
+
+
 def generate_id():
     t = time.time() * 1000000
     b = base64.b32encode(struct.pack(">Q", int(t)).lstrip(b'\x00')).strip(b'=').lower()

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'easy_thumbnails',
     'image_cropping',
+    'autoslug',
 
     'allauth',
     'allauth.account',


### PR DESCRIPTION
Added django-autoslug 1.9.3 and autoslug fields for Unit and Resource. The fields are populated from name field and are unique. Slugs for existing units and resources are generated in migrations.

Refs #24