### PR TITLE
Add resource equipment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
 install:
 - pip install coveralls -r requirements.txt --use-mirrors
 
+before_script:
+  - psql template1 -c 'create extension hstore;'
+
 script: py.test resources
 
 addons:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Installation
 
 ```shell
 sudo -u postgres createuser -L -R -S respa
+sudo -u postgres psql -d template1 -c "create extension hstore;"
 sudo -u postgres createdb -Orespa respa
-sudo -u postgres psql respa
-  CREATE EXTENSION postgis;
+sudo -u postgres psql respa -c "CREATE EXTENSION postgis;"
 ```
 
 2. Run Django migrations and import data

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ django-allauth
 django-autoslug==1.9.3
 djangorestframework-jwt
 pyjwt
+django-hstore==1.4

--- a/resources/admin/__init__.py
+++ b/resources/admin/__init__.py
@@ -5,15 +5,23 @@ from image_cropping import ImageCroppingMixin
 from modeltranslation.admin import TranslationAdmin
 from resources.admin.period_inline import PeriodInline
 from resources.models import Day, Reservation, Resource, ResourceImage, ResourceType, Unit
+from resources.models import Equipment, ResourceEquipment, EquipmentAlias
 
 
 class DayInline(admin.TabularInline):
     model = Day
 
 
+class ResourceEquipmentInline(admin.StackedInline):
+    model = ResourceEquipment
+    exclude = ('id', 'description')
+    extra = 1
+
+
 class ResourceAdmin(TranslationAdmin, geo_admin.OSMGeoAdmin):
     inlines = [
-        PeriodInline
+        PeriodInline,
+        ResourceEquipmentInline,
     ]
 
     default_lon = 2776460  # Central Railway Station in EPSG:3857
@@ -35,9 +43,28 @@ class ResourceImageAdmin(ImageCroppingMixin, TranslationAdmin):
     exclude = ('sort_order', 'image_format')
 
 
+class EquipmentAliasInline(admin.TabularInline):
+    model = EquipmentAlias
+    fields = ('name', 'language')
+    extra = 1
+
+
+class EquipmentAdmin(TranslationAdmin):
+    fields = ('name',)
+    inlines = (
+        EquipmentAliasInline,
+    )
+
+
+class ResourceEquipmentAdmin(TranslationAdmin):
+    pass
+
+
 admin_site.register(ResourceImage, ResourceImageAdmin)
 admin_site.register(Resource, ResourceAdmin)
 admin_site.register(Reservation)
 admin_site.register(ResourceType)
 admin_site.register(Day)
 admin_site.register(Unit, UnitAdmin)
+admin_site.register(Equipment, EquipmentAdmin)
+admin_site.register(ResourceEquipment, ResourceEquipmentAdmin)

--- a/resources/api/base.py
+++ b/resources/api/base.py
@@ -47,16 +47,12 @@ class TranslatedModelSerializer(serializers.ModelSerializer):
             for lang in LANGUAGES:
                 key = "%s_%s" % (field_name, lang)
                 val = getattr(obj, key, None)
-                if val is None:
+                if val in (None, ""):
                     continue
                 d[lang] = val
 
             # If no text provided, leave the field as null
-            for key, val in d.items():
-                if val is not None:
-                    break
-            else:
-                d = None
+            d = (d or None)
             ret[field_name] = d
 
         return ret

--- a/resources/migrations/0018_add_resource_equipment.py
+++ b/resources/migrations/0018_add_resource_equipment.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.utils.timezone
+from django.conf import settings
+import django_hstore.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('resources', '0017_uneditable_internal_fields'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Equipment',
+            fields=[
+                ('created_at', models.DateTimeField(verbose_name='Time of creation', default=django.utils.timezone.now)),
+                ('modified_at', models.DateTimeField(verbose_name='Time of modification', default=django.utils.timezone.now)),
+                ('id', models.CharField(primary_key=True, max_length=100, serialize=False)),
+                ('name', models.CharField(verbose_name='Name', max_length=200)),
+                ('name_fi', models.CharField(verbose_name='Name', null=True, max_length=200)),
+                ('name_en', models.CharField(verbose_name='Name', null=True, max_length=200)),
+                ('name_sv', models.CharField(verbose_name='Name', null=True, max_length=200)),
+                ('created_by', models.ForeignKey(blank=True, verbose_name='Created by', to=settings.AUTH_USER_MODEL, related_name='equipment_created', null=True)),
+                ('modified_by', models.ForeignKey(blank=True, verbose_name='Modified by', to=settings.AUTH_USER_MODEL, related_name='equipment_modified', null=True)),
+            ],
+            options={
+                'verbose_name': 'equipment',
+                'verbose_name_plural': 'equipment',
+            },
+        ),
+        migrations.CreateModel(
+            name='EquipmentAlias',
+            fields=[
+                ('created_at', models.DateTimeField(verbose_name='Time of creation', default=django.utils.timezone.now)),
+                ('modified_at', models.DateTimeField(verbose_name='Time of modification', default=django.utils.timezone.now)),
+                ('id', models.CharField(primary_key=True, max_length=100, serialize=False)),
+                ('name', models.CharField(verbose_name='Name', max_length=200)),
+                ('language', models.CharField(choices=[('fi', 'Finnish'), ('en', 'English'), ('sv', 'Swedish')], max_length=3, default='fi')),
+                ('created_by', models.ForeignKey(blank=True, verbose_name='Created by', to=settings.AUTH_USER_MODEL, related_name='equipmentalias_created', null=True)),
+                ('equipment', models.ForeignKey(related_name='aliases', to='resources.Equipment')),
+                ('modified_by', models.ForeignKey(blank=True, verbose_name='Modified by', to=settings.AUTH_USER_MODEL, related_name='equipmentalias_modified', null=True)),
+            ],
+            options={
+                'verbose_name': 'equipment alias',
+                'verbose_name_plural': 'equipment aliases',
+            },
+        ),
+        migrations.CreateModel(
+            name='ResourceEquipment',
+            fields=[
+                ('id', models.AutoField(auto_created=True, verbose_name='ID', primary_key=True, serialize=False)),
+                ('created_at', models.DateTimeField(verbose_name='Time of creation', default=django.utils.timezone.now)),
+                ('modified_at', models.DateTimeField(verbose_name='Time of modification', default=django.utils.timezone.now)),
+                ('data', django_hstore.fields.DictionaryField(blank=True, null=True)),
+                ('description', models.TextField(blank=True)),
+                ('description_fi', models.TextField(blank=True, null=True)),
+                ('description_en', models.TextField(blank=True, null=True)),
+                ('description_sv', models.TextField(blank=True, null=True)),
+                ('created_by', models.ForeignKey(blank=True, verbose_name='Created by', to=settings.AUTH_USER_MODEL, related_name='resourceequipment_created', null=True)),
+                ('equipment', models.ForeignKey(related_name='resource_equipment', to='resources.Equipment')),
+                ('modified_by', models.ForeignKey(blank=True, verbose_name='Modified by', to=settings.AUTH_USER_MODEL, related_name='resourceequipment_modified', null=True)),
+                ('resource', models.ForeignKey(related_name='resource_equipment', to='resources.Resource')),
+            ],
+            options={
+                'verbose_name': 'resource equipment',
+                'verbose_name_plural': 'resource equipment',
+            },
+        ),
+        migrations.AddField(
+            model_name='resource',
+            name='equipment',
+            field=models.ManyToManyField(verbose_name='Equipment', through='resources.ResourceEquipment', to='resources.Equipment'),
+        ),
+    ]

--- a/resources/models/__init__.py
+++ b/resources/models/__init__.py
@@ -1,4 +1,5 @@
 from .availability import Day, Period, get_opening_hours  # noqa
 from .reservation import Reservation  # noqa
 from .resource import Purpose, Resource, ResourceType, ResourceImage  # noqa
+from .resource import Equipment, ResourceEquipment, EquipmentAlias  # noqa
 from .unit import Unit, UnitIdentifier  # noqa

--- a/resources/pagination.py
+++ b/resources/pagination.py
@@ -1,0 +1,5 @@
+from rest_framework.pagination import PageNumberPagination
+class DefaultPagination(PageNumberPagination):
+    page_size = 20
+    page_size_query_param = 'page_size'  # Allow client to override, using `?page_size=xxx
+    max_page_size = 100

--- a/resources/tests/conftest.py
+++ b/resources/tests/conftest.py
@@ -2,7 +2,7 @@
 import pytest
 from rest_framework.test import APIClient, APIRequestFactory
 
-from resources.models import Resource, ResourceType, Unit
+from resources.models import Resource, ResourceType, Unit, Equipment, EquipmentAlias, ResourceEquipment
 
 
 @pytest.fixture
@@ -31,3 +31,41 @@ def space_resource(space_resource_type):
 @pytest.fixture
 def test_unit():
     return Unit.objects.create(name="unit")
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def resource_in_unit(space_resource_type, test_unit):
+    return Resource.objects.create(
+        type=space_resource_type,
+        authentication="none",
+        name="resource in unit",
+        unit=test_unit,
+    )
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def equipment():
+    equipment = Equipment.objects.create(name='test equipment')
+    return equipment
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def equipment_alias(equipment):
+    equipment_alias = EquipmentAlias.objects.create(name='test equipment alias', language='fi', equipment=equipment)
+    return equipment_alias
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def resource_equipment(resource_in_unit, equipment):
+    data = {'test_key': 'test_value'}
+    resource_equipment = ResourceEquipment.objects.create(
+        equipment=equipment,
+        resource=resource_in_unit,
+        data=data,
+        description='test resource equipment',
+    )
+    return resource_equipment

--- a/resources/tests/test_api_base.py
+++ b/resources/tests/test_api_base.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from resources.api.base import TranslatedModelSerializer
+from resources.models import ResourceEquipment
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def TMS():
+    class TestSerializer(TranslatedModelSerializer):
+        class Meta:
+            model = ResourceEquipment
+    return TestSerializer
+
+
+@pytest.mark.django_db
+def test_translated_model_serializer_language_filtering(TMS, equipment, space_resource):
+    """
+    Tests that TranslatedModelSerializer handles translated fields correctly
+    when some or all of them are empty or None.
+
+    ResourceEquipment model is used in the tests because it has description
+    field that allows blank values.
+    """
+    tms = TMS()
+
+    resource_equipment = ResourceEquipment.objects.create(
+        equipment=equipment,
+        resource=space_resource,
+        description_fi='testiresurssissa olevan testivarusteen kuvaus',
+        description_en=''
+    )
+    representation = tms.to_representation(resource_equipment)
+    description = representation['description']
+    assert description['fi'] == 'testiresurssissa olevan testivarusteen kuvaus'
+    assert 'en' not in description  # empty field should not be included
+    assert 'sv' not in description  # null field should not be included
+
+    resource_equipment_descriptions_null = ResourceEquipment.objects.create(
+        equipment=equipment,
+        resource=space_resource,
+    )
+    representation = tms.to_representation(resource_equipment_descriptions_null)
+    assert representation['description'] is None  # should be None as all description fields are null
+
+    resource_equipment_descriptions_empty = ResourceEquipment.objects.create(
+        equipment=equipment,
+        resource=space_resource,
+        description_fi='',
+        description_en='',
+        description_sv='',
+    )
+
+    representation = tms.to_representation(resource_equipment_descriptions_empty)
+    assert representation['description'] is None  # should be None as all description fields are empty

--- a/resources/tests/test_equipment_api.py
+++ b/resources/tests/test_equipment_api.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from resources.models import Equipment, EquipmentAlias, ResourceEquipment
+from django.core.urlresolvers import reverse
+
+
+@pytest.fixture
+def list_url():
+    return reverse('equipment-list')
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def detail_url(equipment):
+    return reverse('equipment-detail', kwargs={'pk': equipment.pk})
+
+
+def _check_keys_and_values(result):
+    """
+    Check that given dict represents equipment data in correct form.
+    """
+    assert len(result) == 3
+    assert all(key in result for key in ('id', 'name', 'aliases'))
+    assert result['id'] != ""
+    assert result['name'] == {'fi': 'test equipment'}
+    aliases = result['aliases']
+    assert len(aliases) == 1
+    assert aliases[0]['name'] == 'test equipment alias'
+    assert aliases[0]['language'] == 'fi'
+
+
+@pytest.mark.django_db
+def test_non_allowed_methods(api_client, list_url, detail_url):
+    """
+    Tests that only safe methods are allowed to equipment list and detail endpoints.
+    """
+    for url in (list_url, detail_url):
+        for method in ('post', 'put', 'patch', 'delete'):
+            assert getattr(api_client, method)(url).status_code in (401, 405)
+
+
+
+@pytest.mark.django_db
+def test_get_equipment_list(api_client, list_url, equipment, equipment_alias):
+    """
+    Tests that equipment list endpoint return equipment data in correct form.
+    """
+    response = api_client.get(list_url)
+    results = response.data['results']
+    assert len(results) == 1
+    _check_keys_and_values(results[0])
+
+
+@pytest.mark.django_db
+def test_get_equipment_detail(api_client, detail_url, equipment, equipment_alias):
+    """
+    Tests that equipment detail endpoint returns equipment data in correct form.
+    """
+    response = api_client.get(detail_url)
+    _check_keys_and_values(response.data)
+
+
+@pytest.mark.django_db
+def test_get_equipment_in_resource(api_client, resource_in_unit, resource_equipment):
+    """
+    Tests that combined resource equipment and equipment data is available via resource endpoint.
+
+    Equipment aliases should not be included.
+    """
+    response = api_client.get(reverse('resource-detail', kwargs={'pk': resource_in_unit.pk}))
+    equipments = response.data['equipment']
+    assert len(equipments) == 1
+    equipment = equipments[0]
+    assert all(key in equipment for key in ('id', 'name', 'data', 'description'))
+    assert 'aliases' not in equipment
+    assert equipment['data']['test_key'] == 'test_value'
+    assert equipment['description'] == {'fi': 'test resource equipment'}
+    assert equipment['name'] == {'fi': 'test equipment'}

--- a/resources/translation.py
+++ b/resources/translation.py
@@ -1,6 +1,6 @@
 from modeltranslation.translator import TranslationOptions, register
 
-from .models import Unit, Resource, ResourceType, ResourceImage, Purpose
+from .models import Unit, Resource, ResourceType, ResourceImage, Purpose, Equipment, ResourceEquipment
 
 
 @register(Unit)
@@ -27,3 +27,13 @@ class ResourceImageTranslationOptions(TranslationOptions):
 @register(Purpose)
 class PurposeTranslationOptions(TranslationOptions):
     fields = ('name',)
+
+
+@register(Equipment)
+class EquipmentTranslationOptions(TranslationOptions):
+    fields = ('name',)
+
+
+@register(ResourceEquipment)
+class ResourceEquipmentTranslationOptions(TranslationOptions):
+    fields = ('description',)

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     'easy_thumbnails',
     'image_cropping',
     'autoslug',
+    'django_hstore',
 
     'allauth',
     'allauth.account',

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -168,15 +168,13 @@ SOCIALACCOUNT_ADAPTER = 'helusers.providers.helsinki.provider.SocialAccountAdapt
 # http://www.django-rest-framework.org
 
 REST_FRAMEWORK = {
-    'PAGINATE_BY': 20,                 # Default to 10
-    'PAGINATE_BY_PARAM': 'page_size',  # Allow client to override, using `?page_size=xxx`.
-    'MAX_PAGINATE_BY': 100,             # Maximum limit allowed when using `?page_size=xxx`.
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'helusers.jwt.JWTAuthentication',
     ),
+    'DEFAULT_PAGINATION_CLASS': 'resources.pagination.DefaultPagination',
 }
 
 JWT_AUTH = {


### PR DESCRIPTION
- Added Equipment model and M2M through model ResourceEquipment between it and resources, which has also additional description field and data hstore. 

- For admin UI, added Equipment and ResourceEquipment to their own pages, and also inlined ResourceEquipment in Resource's admin page.

- For API, Equipment has it's own resource at the api root. Resource equipments
are inlined in resources' "equipments" field alongside equipment name
and id.

- Fixed TraslatedModelSerializer language filtering to exclude empty string fields in addition to null ones.

- Added installation of postgres hstore extension to Travis configuration.

- Fixed Django Rest Framework 3.3.x compatibility by adding an own pagination class that implements the same functionality as previously.

Refs #41 #52