### PR TITLE
Add Django LocaleMiddleware.

### DIFF
--- a/respa/settings.py
+++ b/respa/settings.py
@@ -64,6 +64,7 @@ if DEBUG:
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'corsheaders.middleware.CorsMiddleware',


### PR DESCRIPTION
Added LocaleMiddleware so that DRF returns translated error messages
in language set in Accept-Language header.

Refs #58 