### PR TITLE
Limit active reservations.

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-02 17:23+0300\n"
+"POT-Creation-Date: 2015-11-12 16:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,391 +17,507 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: resources/admin.py:12 resources/admin.py:15
-msgid "RESPA Resource booking system"
-msgstr "RESPA Resurssien varausjärjestelmä"
+#: resources/admin/period_inline.py:38
+msgid "HH:mm"
+msgstr ""
 
-#: resources/admin.py:18
-msgid "RESPA Administration"
-msgstr "RESPA Ylläpito"
-
-#: resources/apps.py:6
+#: resources/apps.py:7
 msgid "Resource app"
 msgstr "Resurssisovellus"
 
-#: resources/models.py:76
-msgid "Time of creation"
-msgstr "Lisäysaika"
-
-#: resources/models.py:77
-msgid "Created by"
-msgstr "Lisääjä"
-
-#: resources/models.py:79
-msgid "Time of modification"
-msgstr "Muokkausaika"
-
-#: resources/models.py:80
-msgid "Modified by"
-msgstr "Muokkaaja"
-
-#: resources/models.py:172 resources/models.py:234 resources/models.py:255
-#: resources/models.py:276 resources/models.py:584
-msgid "Name"
-msgstr "Nimi"
-
-#: resources/models.py:173 resources/models.py:277 resources/models.py:585
-msgid "Description"
-msgstr "Kuvaus"
-
-#: resources/models.py:175 resources/models.py:287
-msgid "Location"
-msgstr "Sijainti"
-
-#: resources/models.py:176
-msgid "Time zone"
-msgstr "Aikavyöhyke"
-
-#: resources/models.py:181
-msgid "Street address"
-msgstr "Katuosoite"
-
-#: resources/models.py:182
-msgid "Postal code"
-msgstr "Postinumero"
-
-#: resources/models.py:183
-msgid "Phone number"
-msgstr "Puhelinnumero"
-
-#: resources/models.py:184
-msgid "Email"
-msgstr "Sähköpostiosoite"
-
-#: resources/models.py:185
-msgid "WWW link"
-msgstr "Www-osoite"
-
-#: resources/models.py:186
-msgid "Full postal address"
-msgstr "Täysi postiosoite"
-
-#: resources/models.py:189
-msgid "Picture URL"
-msgstr "Valokuvan osoite"
-
-#: resources/models.py:191
-msgid "Picture caption"
-msgstr "Valokuvan kuvateksti"
-
-#: resources/models.py:195
-msgid "unit"
-msgstr "toimipiste"
-
-#: resources/models.py:196
-msgid "units"
-msgstr "toimipisteet"
-
-#: resources/models.py:216 resources/models.py:272 resources/models.py:576
-msgid "Unit"
-msgstr "Toimipiste"
-
-#: resources/models.py:217
-msgid "Namespace"
-msgstr "Tunnisteavaruus"
-
-#: resources/models.py:218
-msgid "Value"
-msgstr "Arvo"
-
-#: resources/models.py:221
-msgid "unit identifier"
-msgstr "toimipisteen tunniste"
-
-#: resources/models.py:222
-msgid "unit identifiers"
-msgstr "toimipisteen tunnisteet"
-
-#: resources/models.py:228
-msgid "Space"
-msgstr "Tila"
-
-#: resources/models.py:229
-msgid "Person"
-msgstr "Henkilö"
-
-#: resources/models.py:230
-msgid "Item"
-msgstr "Esine"
-
-#: resources/models.py:233 resources/models.py:254
-msgid "Main type"
-msgstr "Päätyyppi"
-
-#: resources/models.py:237
-msgid "resource type"
-msgstr "resurssityyppi"
-
-#: resources/models.py:238
-msgid "resource types"
-msgstr "resurssityypit"
-
-#: resources/models.py:246
-msgid "Audiovisual work"
-msgstr "Audiovisuaalinen työskentely"
-
-#: resources/models.py:247
-msgid "Manufacturing"
-msgstr "Fyysisten esineiden tekeminen"
-
-#: resources/models.py:248
-msgid "Watch and listen"
-msgstr "Katselu ja kuuntelu"
-
-#: resources/models.py:249
-msgid "Meet and work"
-msgstr "Kokoontuminen ja työskentely"
-
-#: resources/models.py:250
-msgid "Games"
-msgstr "Pelaaminen"
-
-#: resources/models.py:251
-msgid "Events and exhibitions"
-msgstr "Tapahtumat ja näyttelyt"
-
-#: resources/models.py:258
-msgid "purpose"
-msgstr "käyttötarkoitus"
-
-#: resources/models.py:259
-msgid "purposes"
-msgstr "käyttötarkoitukset"
-
-#: resources/models.py:267
-msgid "None"
-msgstr "Ei mitään"
-
-#: resources/models.py:268
-msgid "Weak"
-msgstr "Heikko"
-
-#: resources/models.py:269
-msgid "Strong"
-msgstr "Vahva"
-
-#: resources/models.py:274
-msgid "Resource type"
-msgstr "Resurssityyppi"
-
-#: resources/models.py:275
-msgid "Purposes"
-msgstr "Käyttötarkoitukset"
-
-#: resources/models.py:278
-msgid "Photo URL"
-msgstr "Valokuvan osoite"
-
-#: resources/models.py:279
-msgid "Need manual confirmation"
-msgstr "Tarvitsee virkailijan vahvistuksen"
-
-#: resources/models.py:280
-msgid "Authentication"
-msgstr "Tunnistautuminen"
-
-#: resources/models.py:282
-msgid "People capacity"
-msgstr "Henkilömäärä"
-
-#: resources/models.py:283
-msgid "Area"
-msgstr "Pinta-ala"
-
-#: resources/models.py:284
-msgid "Ground plan URL"
-msgstr "Pohjapiirroksen osoite"
-
-#: resources/models.py:289
-msgid "Minimum reservation time"
-msgstr "Lyhin varausaika"
-
-#: resources/models.py:291
-msgid "Maximum reservation time"
-msgstr "Pisin varausaika"
-
-#: resources/models.py:294
-msgid "resource"
-msgstr "resurssi"
-
-#: resources/models.py:295
-msgid "resources"
-msgstr "resurssit"
-
-#: resources/models.py:326
-msgid "No hours for reservation period"
-msgstr ""
-
-#: resources/models.py:333
-msgid "You must end the reservation after it has begun"
-msgstr ""
-
-#: resources/models.py:335
-msgid "You must start the reservation during opening hours"
-msgstr ""
-
-#: resources/models.py:337
-msgid "You must end the reservation before closing"
-msgstr ""
-
-#: resources/models.py:347
-msgid "The minimum duration for a reservation is "
-msgstr ""
-
-#: resources/models.py:350
-msgid "The maximum reservation length is "
-msgstr ""
-
-#: resources/models.py:355
-msgid "The resource is already reserved for some of the period"
-msgstr ""
-
-#: resources/models.py:500 resources/models.py:574
-msgid "Resource"
-msgstr "Resurssi"
-
-#: resources/models.py:501
-msgid "Begin time"
-msgstr "Alkuaika"
-
-#: resources/models.py:502
-msgid "End time"
-msgstr "Loppuaika"
-
-#: resources/models.py:503
-msgid "Length of reservation"
-msgstr "Varauksen kesto"
-
-#: resources/models.py:505
-msgid "User"
-msgstr "Käyttäjä"
-
-#: resources/models.py:551
-msgid "reservation"
-msgstr "varaus"
-
-#: resources/models.py:552
-msgid "reservations"
-msgstr "varaukset"
-
-#: resources/models.py:564
+#: resources/models/availability.py:14
 msgid "open"
 msgstr "auki"
 
-#: resources/models.py:564
+#: resources/models/availability.py:14
 msgid "closed"
 msgstr "kiinni"
 
-#: resources/models.py:572 resources/models.py:590
-msgid "period"
-msgstr "aikaväli"
+#: resources/models/availability.py:105
+#, fuzzy
+#| msgid "Exceptional period"
+msgid "exception parent period"
+msgstr "Poikkeusaikaväli"
 
-#: resources/models.py:573
+#: resources/models/availability.py:106
 msgid "Exceptional period"
 msgstr "Poikkeusaikaväli"
 
-#: resources/models.py:579
+#: resources/models/availability.py:107 resources/models/reservation.py:12
+#: resources/models/resource.py:307
+msgid "Resource"
+msgstr "Resurssi"
+
+#: resources/models/availability.py:109 resources/models/resource.py:71
+#: resources/models/unit.py:63
+msgid "Unit"
+msgstr "Toimipiste"
+
+#: resources/models/availability.py:112
 msgid "Start date"
 msgstr "Alkupäivä"
 
-#: resources/models.py:580
+#: resources/models/availability.py:113
 msgid "End date"
 msgstr "Loppupäivä"
 
-#: resources/models.py:581
+#: resources/models/availability.py:114
 msgid "Length of period"
 msgstr "Aikavälin kesto"
 
-#: resources/models.py:587 resources/models.py:703
+#: resources/models/availability.py:117 resources/models/equipment.py:11
+#: resources/models/equipment.py:23 resources/models/equipment.py:36
+#: resources/models/resource.py:33 resources/models/resource.py:54
+#: resources/models/resource.py:75 resources/models/unit.py:16
+msgid "Name"
+msgstr "Nimi"
+
+#: resources/models/availability.py:118 resources/models/resource.py:76
+#: resources/models/unit.py:17
+msgid "Description"
+msgstr "Kuvaus"
+
+#: resources/models/availability.py:120 resources/models/availability.py:271
 msgid "Closed"
 msgstr "Kiinni"
 
-#: resources/models.py:591
+#: resources/models/availability.py:123
+msgid "period"
+msgstr "aikaväli"
+
+#: resources/models/availability.py:124
 msgid "periods"
 msgstr "aikavälit"
 
-#: resources/models.py:615
+#: resources/models/availability.py:210
+#, fuzzy
+#| msgid "You must set either 'resource' or 'unit', but not both"
+msgid "You must set 'resource' or 'unit'"
+msgstr "Aseta 'resource' tai 'unit', älä molempia"
+
+#: resources/models/availability.py:213
 msgid "You must set either 'resource' or 'unit', but not both"
 msgstr "Aseta 'resource' tai 'unit', älä molempia"
 
-#: resources/models.py:687
+#: resources/models/availability.py:255
 msgid "Monday"
 msgstr "Maanantai"
 
-#: resources/models.py:688
+#: resources/models/availability.py:256
 msgid "Tuesday"
 msgstr "Tiistai"
 
-#: resources/models.py:689
+#: resources/models/availability.py:257
 msgid "Wednesday"
 msgstr "Keskiviikko"
 
-#: resources/models.py:690
+#: resources/models/availability.py:258
 msgid "Thursday"
 msgstr "Torstai"
 
-#: resources/models.py:691
+#: resources/models/availability.py:259
 msgid "Friday"
 msgstr "Perjantai"
 
-#: resources/models.py:692
+#: resources/models/availability.py:260
 msgid "Saturday"
 msgstr "Lauantai"
 
-#: resources/models.py:693
+#: resources/models/availability.py:261
 msgid "Sunday"
 msgstr "Sunnuntai"
 
-#: resources/models.py:696
+#: resources/models/availability.py:264
 msgid "Period"
 msgstr "Aikaväli"
 
-#: resources/models.py:697
+#: resources/models/availability.py:265
 msgid "Weekday"
 msgstr "Viikonpäivä"
 
-#: resources/models.py:698
+#: resources/models/availability.py:266
 msgid "Time when opens"
 msgstr "Aukeamisaika"
 
-#: resources/models.py:699
+#: resources/models/availability.py:267
 msgid "Time when closes"
 msgstr "Kiinnimenoaika"
 
-#: resources/models.py:700
+#: resources/models/availability.py:268
 msgid "Range between opens and closes"
 msgstr ""
 
-#: resources/models.py:704
+#: resources/models/availability.py:272
 msgid "description"
 msgstr "kuvaus"
 
-#: resources/models.py:707
+#: resources/models/availability.py:275
 msgid "day"
 msgstr "päivä"
 
-#: resources/models.py:708
+#: resources/models/availability.py:276
 msgid "days"
 msgstr "päivät"
 
-#: respa/settings.py:106
+#: resources/models/base.py:27
+msgid "Time of creation"
+msgstr "Lisäysaika"
+
+#: resources/models/base.py:28
+msgid "Created by"
+msgstr "Lisääjä"
+
+#: resources/models/base.py:30
+msgid "Time of modification"
+msgstr "Muokkausaika"
+
+#: resources/models/base.py:31
+msgid "Modified by"
+msgstr "Muokkaaja"
+
+#: resources/models/equipment.py:14
+msgid "equipment category"
+msgstr ""
+
+#: resources/models/equipment.py:15
+msgid "equipment categories"
+msgstr ""
+
+#: resources/models/equipment.py:24
+msgid "Category"
+msgstr ""
+
+#: resources/models/equipment.py:27 resources/models/equipment.py:28
+msgid "equipment"
+msgstr ""
+
+#: resources/models/equipment.py:41
+msgid "equipment alias"
+msgstr ""
+
+#: resources/models/equipment.py:42
+msgid "equipment aliases"
+msgstr ""
+
+#: resources/models/reservation.py:13
+msgid "Begin time"
+msgstr "Alkuaika"
+
+#: resources/models/reservation.py:14
+msgid "End time"
+msgstr "Loppuaika"
+
+#: resources/models/reservation.py:15
+msgid "Length of reservation"
+msgstr "Varauksen kesto"
+
+#: resources/models/reservation.py:17
+msgid "User"
+msgstr "Käyttäjä"
+
+#: resources/models/reservation.py:63
+msgid "reservation"
+msgstr "varaus"
+
+#: resources/models/reservation.py:64
+msgid "reservations"
+msgstr "varaukset"
+
+#: resources/models/resource.py:27
+msgid "Space"
+msgstr "Tila"
+
+#: resources/models/resource.py:28
+msgid "Person"
+msgstr "Henkilö"
+
+#: resources/models/resource.py:29
+msgid "Item"
+msgstr "Esine"
+
+#: resources/models/resource.py:32 resources/models/resource.py:53
+msgid "Main type"
+msgstr "Päätyyppi"
+
+#: resources/models/resource.py:36
+msgid "resource type"
+msgstr "resurssityyppi"
+
+#: resources/models/resource.py:37
+msgid "resource types"
+msgstr "resurssityypit"
+
+#: resources/models/resource.py:45
+msgid "Audiovisual work"
+msgstr "Audiovisuaalinen työskentely"
+
+#: resources/models/resource.py:46
+msgid "Manufacturing"
+msgstr "Fyysisten esineiden tekeminen"
+
+#: resources/models/resource.py:47
+msgid "Watch and listen"
+msgstr "Katselu ja kuuntelu"
+
+#: resources/models/resource.py:48
+msgid "Meet and work"
+msgstr "Kokoontuminen ja työskentely"
+
+#: resources/models/resource.py:49
+msgid "Games"
+msgstr "Pelaaminen"
+
+#: resources/models/resource.py:50
+msgid "Events and exhibitions"
+msgstr "Tapahtumat ja näyttelyt"
+
+#: resources/models/resource.py:57
+msgid "purpose"
+msgstr "käyttötarkoitus"
+
+#: resources/models/resource.py:58
+msgid "purposes"
+msgstr "käyttötarkoitukset"
+
+#: resources/models/resource.py:66
+msgid "None"
+msgstr "Ei mitään"
+
+#: resources/models/resource.py:67
+msgid "Weak"
+msgstr "Heikko"
+
+#: resources/models/resource.py:68
+msgid "Strong"
+msgstr "Vahva"
+
+#: resources/models/resource.py:73
+msgid "Resource type"
+msgstr "Resurssityyppi"
+
+#: resources/models/resource.py:74
+msgid "Purposes"
+msgstr "Käyttötarkoitukset"
+
+#: resources/models/resource.py:77
+msgid "Need manual confirmation"
+msgstr "Tarvitsee virkailijan vahvistuksen"
+
+#: resources/models/resource.py:78
+msgid "Authentication"
+msgstr "Tunnistautuminen"
+
+#: resources/models/resource.py:80
+msgid "People capacity"
+msgstr "Henkilömäärä"
+
+#: resources/models/resource.py:81
+msgid "Area"
+msgstr "Pinta-ala"
+
+#: resources/models/resource.py:84 resources/models/unit.py:19
+msgid "Location"
+msgstr "Sijainti"
+
+#: resources/models/resource.py:86
+msgid "Minimum reservation time"
+msgstr "Lyhin varausaika"
+
+#: resources/models/resource.py:88
+msgid "Maximum reservation time"
+msgstr "Pisin varausaika"
+
+#: resources/models/resource.py:91
+msgid "Equipment"
+msgstr ""
+
+#: resources/models/resource.py:92
+msgid "Maximum number of active reservations per user"
+msgstr "Max. varaukset per käyttäjä (voimassa olevat)"
+
+#: resources/models/resource.py:96
+msgid "resource"
+msgstr "resurssi"
+
+#: resources/models/resource.py:97
+msgid "resources"
+msgstr "resurssit"
+
+#: resources/models/resource.py:128
+msgid "No hours for reservation period"
+msgstr ""
+
+#: resources/models/resource.py:135
+msgid "You must end the reservation after it has begun"
+msgstr ""
+
+#: resources/models/resource.py:137
+msgid "You must start the reservation during opening hours"
+msgstr ""
+
+#: resources/models/resource.py:139
+msgid "You must end the reservation before closing"
+msgstr ""
+
+#: resources/models/resource.py:147
+msgid "The minimum duration for a reservation is "
+msgstr ""
+
+#: resources/models/resource.py:150
+msgid "The maximum reservation length is "
+msgstr ""
+
+#: resources/models/resource.py:155
+msgid "The resource is already reserved for some of the period"
+msgstr ""
+
+#: resources/models/resource.py:302
+#, fuzzy
+#| msgid "Main type"
+msgid "Main photo"
+msgstr "Päätyyppi"
+
+#: resources/models/resource.py:303
+#, fuzzy
+#| msgid "Ground plan URL"
+msgid "Ground plan"
+msgstr "Pohjapiirroksen osoite"
+
+#: resources/models/resource.py:304
+msgid "Map"
+msgstr ""
+
+#: resources/models/resource.py:305
+msgid "Other"
+msgstr ""
+
+#: resources/models/resource.py:309
+msgid "Type"
+msgstr ""
+
+#: resources/models/resource.py:310
+#, fuzzy
+#| msgid "Location"
+msgid "Caption"
+msgstr "Sijainti"
+
+#: resources/models/resource.py:312
+msgid "Image"
+msgstr ""
+
+#: resources/models/resource.py:314
+msgid "Cropping"
+msgstr ""
+
+#: resources/models/resource.py:315
+msgid "Sort order"
+msgstr ""
+
+#: resources/models/resource.py:383
+#, fuzzy
+#| msgid "resource type"
+msgid "resource image"
+msgstr "resurssityyppi"
+
+#: resources/models/resource.py:384
+#, fuzzy
+#| msgid "resource types"
+msgid "resource images"
+msgstr "resurssityypit"
+
+#: resources/models/resource.py:402 resources/models/resource.py:403
+#, fuzzy
+#| msgid "resource type"
+msgid "resource equipment"
+msgstr "resurssityyppi"
+
+#: resources/models/unit.py:20
+msgid "Time zone"
+msgstr "Aikavyöhyke"
+
+#: resources/models/unit.py:25
+msgid "Street address"
+msgstr "Katuosoite"
+
+#: resources/models/unit.py:26
+msgid "Postal code"
+msgstr "Postinumero"
+
+#: resources/models/unit.py:27
+msgid "Phone number"
+msgstr "Puhelinnumero"
+
+#: resources/models/unit.py:28
+msgid "Email"
+msgstr "Sähköpostiosoite"
+
+#: resources/models/unit.py:29
+msgid "WWW link"
+msgstr "Www-osoite"
+
+#: resources/models/unit.py:30
+msgid "Full postal address"
+msgstr "Täysi postiosoite"
+
+#: resources/models/unit.py:33
+msgid "Picture URL"
+msgstr "Valokuvan osoite"
+
+#: resources/models/unit.py:35
+msgid "Picture caption"
+msgstr "Valokuvan kuvateksti"
+
+#: resources/models/unit.py:41
+msgid "unit"
+msgstr "toimipiste"
+
+#: resources/models/unit.py:42
+msgid "units"
+msgstr "toimipisteet"
+
+#: resources/models/unit.py:64
+msgid "Namespace"
+msgstr "Tunnisteavaruus"
+
+#: resources/models/unit.py:65
+msgid "Value"
+msgstr "Arvo"
+
+#: resources/models/unit.py:68
+msgid "unit identifier"
+msgstr "toimipisteen tunniste"
+
+#: resources/models/unit.py:69
+msgid "unit identifiers"
+msgstr "toimipisteen tunnisteet"
+
+#: resources/templates/admin/resources/period_inline.html:10
+msgid "Add Another"
+msgstr ""
+
+#: resources/templates/admin/resources/period_inline.html:36
+msgid "Delete Item"
+msgstr ""
+
+#: respa/settings.py:117 respa/settings_local.py:116
 msgid "Finnish"
 msgstr "suomi"
 
-#: respa/settings.py:107
+#: respa/settings.py:118 respa/settings_local.py:117
 msgid "English"
 msgstr "englanti"
 
-#: respa/settings.py:108
+#: respa/settings.py:119 respa/settings_local.py:118
 msgid "Swedish"
 msgstr "ruotsi"
+
+#: respa/urls.py:26 respa/urls.py:29
+msgid "RESPA Resource booking system"
+msgstr "RESPA Resurssien varausjärjestelmä"
+
+#: respa/urls.py:32
+msgid "RESPA Administration"
+msgstr "RESPA Ylläpito"
+
+#~ msgid "Photo URL"
+#~ msgstr "Valokuvan osoite"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-11-12 16:38+0200\n"
+"POT-Creation-Date: 2015-11-13 12:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,6 +20,10 @@ msgstr ""
 #: resources/admin/period_inline.py:38
 msgid "HH:mm"
 msgstr ""
+
+#: resources/api/reservation.py:53
+msgid "Maximum number of active reservations for this resource exceeded."
+msgstr "Liikaa voimassa olevia varauksia tähän resurssiin."
 
 #: resources/apps.py:7
 msgid "Resource app"
@@ -43,7 +47,7 @@ msgstr "Poikkeusaikaväli"
 msgid "Exceptional period"
 msgstr "Poikkeusaikaväli"
 
-#: resources/models/availability.py:107 resources/models/reservation.py:12
+#: resources/models/availability.py:107 resources/models/reservation.py:18
 #: resources/models/resource.py:307
 msgid "Resource"
 msgstr "Resurssi"
@@ -199,27 +203,27 @@ msgstr ""
 msgid "equipment aliases"
 msgstr ""
 
-#: resources/models/reservation.py:13
+#: resources/models/reservation.py:19
 msgid "Begin time"
 msgstr "Alkuaika"
 
-#: resources/models/reservation.py:14
+#: resources/models/reservation.py:20
 msgid "End time"
 msgstr "Loppuaika"
 
-#: resources/models/reservation.py:15
+#: resources/models/reservation.py:21
 msgid "Length of reservation"
 msgstr "Varauksen kesto"
 
-#: resources/models/reservation.py:17
+#: resources/models/reservation.py:23
 msgid "User"
 msgstr "Käyttäjä"
 
-#: resources/models/reservation.py:63
+#: resources/models/reservation.py:72
 msgid "reservation"
 msgstr "varaus"
 
-#: resources/models/reservation.py:64
+#: resources/models/reservation.py:73
 msgid "reservations"
 msgstr "varaukset"
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-11-13 12:41+0200\n"
+"POT-Creation-Date: 2015-11-17 11:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 
 #: resources/admin/period_inline.py:38
 msgid "HH:mm"
-msgstr ""
+msgstr "TT:mm"
 
 #: resources/api/reservation.py:53
 msgid "Maximum number of active reservations for this resource exceeded."
@@ -38,21 +38,19 @@ msgid "closed"
 msgstr "kiinni"
 
 #: resources/models/availability.py:105
-#, fuzzy
-#| msgid "Exceptional period"
 msgid "exception parent period"
-msgstr "Poikkeusaikaväli"
+msgstr "Poikkeusaikavälin kohde"
 
 #: resources/models/availability.py:106
 msgid "Exceptional period"
 msgstr "Poikkeusaikaväli"
 
 #: resources/models/availability.py:107 resources/models/reservation.py:18
-#: resources/models/resource.py:307
+#: resources/models/resource.py:308
 msgid "Resource"
 msgstr "Resurssi"
 
-#: resources/models/availability.py:109 resources/models/resource.py:71
+#: resources/models/availability.py:109 resources/models/resource.py:72
 #: resources/models/unit.py:63
 msgid "Unit"
 msgstr "Toimipiste"
@@ -69,14 +67,14 @@ msgstr "Loppupäivä"
 msgid "Length of period"
 msgstr "Aikavälin kesto"
 
-#: resources/models/availability.py:117 resources/models/equipment.py:11
-#: resources/models/equipment.py:23 resources/models/equipment.py:36
-#: resources/models/resource.py:33 resources/models/resource.py:54
-#: resources/models/resource.py:75 resources/models/unit.py:16
+#: resources/models/availability.py:117 resources/models/equipment.py:12
+#: resources/models/equipment.py:24 resources/models/equipment.py:37
+#: resources/models/resource.py:34 resources/models/resource.py:55
+#: resources/models/resource.py:76 resources/models/unit.py:16
 msgid "Name"
 msgstr "Nimi"
 
-#: resources/models/availability.py:118 resources/models/resource.py:76
+#: resources/models/availability.py:118 resources/models/resource.py:77
 #: resources/models/unit.py:17
 msgid "Description"
 msgstr "Kuvaus"
@@ -94,10 +92,8 @@ msgid "periods"
 msgstr "aikavälit"
 
 #: resources/models/availability.py:210
-#, fuzzy
-#| msgid "You must set either 'resource' or 'unit', but not both"
 msgid "You must set 'resource' or 'unit'"
-msgstr "Aseta 'resource' tai 'unit', älä molempia"
+msgstr "Aseta 'resource' tai 'unit'"
 
 #: resources/models/availability.py:213
 msgid "You must set either 'resource' or 'unit', but not both"
@@ -105,31 +101,31 @@ msgstr "Aseta 'resource' tai 'unit', älä molempia"
 
 #: resources/models/availability.py:255
 msgid "Monday"
-msgstr "Maanantai"
+msgstr "maanantai"
 
 #: resources/models/availability.py:256
 msgid "Tuesday"
-msgstr "Tiistai"
+msgstr "tiistai"
 
 #: resources/models/availability.py:257
 msgid "Wednesday"
-msgstr "Keskiviikko"
+msgstr "keskiviikko"
 
 #: resources/models/availability.py:258
 msgid "Thursday"
-msgstr "Torstai"
+msgstr "torstai"
 
 #: resources/models/availability.py:259
 msgid "Friday"
-msgstr "Perjantai"
+msgstr "perjantai"
 
 #: resources/models/availability.py:260
 msgid "Saturday"
-msgstr "Lauantai"
+msgstr "lauantai"
 
 #: resources/models/availability.py:261
 msgid "Sunday"
-msgstr "Sunnuntai"
+msgstr "sunnuntai"
 
 #: resources/models/availability.py:264
 msgid "Period"
@@ -145,11 +141,11 @@ msgstr "Aukeamisaika"
 
 #: resources/models/availability.py:267
 msgid "Time when closes"
-msgstr "Kiinnimenoaika"
+msgstr "Sulkemisaika"
 
 #: resources/models/availability.py:268
 msgid "Range between opens and closes"
-msgstr ""
+msgstr "Aukioloajan pituus"
 
 #: resources/models/availability.py:272
 msgid "description"
@@ -179,29 +175,35 @@ msgstr "Muokkausaika"
 msgid "Modified by"
 msgstr "Muokkaaja"
 
-#: resources/models/equipment.py:14
-msgid "equipment category"
-msgstr ""
-
 #: resources/models/equipment.py:15
+msgid "equipment category"
+msgstr "varusteluokka"
+
+#: resources/models/equipment.py:16
 msgid "equipment categories"
-msgstr ""
+msgstr "varusteluokat"
 
-#: resources/models/equipment.py:24
+#: resources/models/equipment.py:25
 msgid "Category"
-msgstr ""
+msgstr "Luokka"
 
-#: resources/models/equipment.py:27 resources/models/equipment.py:28
+#: resources/models/equipment.py:28
+msgctxt "singular"
 msgid "equipment"
-msgstr ""
+msgstr "varuste"
 
-#: resources/models/equipment.py:41
-msgid "equipment alias"
-msgstr ""
+#: resources/models/equipment.py:29
+msgctxt "plural"
+msgid "equipment"
+msgstr "varusteet"
 
 #: resources/models/equipment.py:42
+msgid "equipment alias"
+msgstr "varusteen toinen nimi"
+
+#: resources/models/equipment.py:43
 msgid "equipment aliases"
-msgstr ""
+msgstr "varusteen toiset nimet"
 
 #: resources/models/reservation.py:19
 msgid "Begin time"
@@ -227,213 +229,207 @@ msgstr "varaus"
 msgid "reservations"
 msgstr "varaukset"
 
-#: resources/models/resource.py:27
+#: resources/models/resource.py:28
 msgid "Space"
 msgstr "Tila"
 
-#: resources/models/resource.py:28
+#: resources/models/resource.py:29
 msgid "Person"
 msgstr "Henkilö"
 
-#: resources/models/resource.py:29
+#: resources/models/resource.py:30
 msgid "Item"
 msgstr "Esine"
 
-#: resources/models/resource.py:32 resources/models/resource.py:53
+#: resources/models/resource.py:33 resources/models/resource.py:54
 msgid "Main type"
 msgstr "Päätyyppi"
 
-#: resources/models/resource.py:36
+#: resources/models/resource.py:37
 msgid "resource type"
 msgstr "resurssityyppi"
 
-#: resources/models/resource.py:37
+#: resources/models/resource.py:38
 msgid "resource types"
 msgstr "resurssityypit"
 
-#: resources/models/resource.py:45
+#: resources/models/resource.py:46
 msgid "Audiovisual work"
 msgstr "Audiovisuaalinen työskentely"
 
-#: resources/models/resource.py:46
+#: resources/models/resource.py:47
 msgid "Manufacturing"
 msgstr "Fyysisten esineiden tekeminen"
 
-#: resources/models/resource.py:47
+#: resources/models/resource.py:48
 msgid "Watch and listen"
 msgstr "Katselu ja kuuntelu"
 
-#: resources/models/resource.py:48
+#: resources/models/resource.py:49
 msgid "Meet and work"
 msgstr "Kokoontuminen ja työskentely"
 
-#: resources/models/resource.py:49
+#: resources/models/resource.py:50
 msgid "Games"
 msgstr "Pelaaminen"
 
-#: resources/models/resource.py:50
+#: resources/models/resource.py:51
 msgid "Events and exhibitions"
 msgstr "Tapahtumat ja näyttelyt"
 
-#: resources/models/resource.py:57
+#: resources/models/resource.py:58
 msgid "purpose"
 msgstr "käyttötarkoitus"
 
-#: resources/models/resource.py:58
+#: resources/models/resource.py:59
 msgid "purposes"
 msgstr "käyttötarkoitukset"
 
-#: resources/models/resource.py:66
+#: resources/models/resource.py:67
 msgid "None"
 msgstr "Ei mitään"
 
-#: resources/models/resource.py:67
+#: resources/models/resource.py:68
 msgid "Weak"
 msgstr "Heikko"
 
-#: resources/models/resource.py:68
+#: resources/models/resource.py:69
 msgid "Strong"
 msgstr "Vahva"
 
-#: resources/models/resource.py:73
+#: resources/models/resource.py:74
 msgid "Resource type"
 msgstr "Resurssityyppi"
 
-#: resources/models/resource.py:74
+#: resources/models/resource.py:75
 msgid "Purposes"
 msgstr "Käyttötarkoitukset"
 
-#: resources/models/resource.py:77
+#: resources/models/resource.py:78
 msgid "Need manual confirmation"
 msgstr "Tarvitsee virkailijan vahvistuksen"
 
-#: resources/models/resource.py:78
+#: resources/models/resource.py:79
 msgid "Authentication"
 msgstr "Tunnistautuminen"
 
-#: resources/models/resource.py:80
+#: resources/models/resource.py:81
 msgid "People capacity"
 msgstr "Henkilömäärä"
 
-#: resources/models/resource.py:81
+#: resources/models/resource.py:82
 msgid "Area"
 msgstr "Pinta-ala"
 
-#: resources/models/resource.py:84 resources/models/unit.py:19
+#: resources/models/resource.py:85 resources/models/unit.py:19
 msgid "Location"
 msgstr "Sijainti"
 
-#: resources/models/resource.py:86
+#: resources/models/resource.py:87
 msgid "Minimum reservation time"
 msgstr "Lyhin varausaika"
 
-#: resources/models/resource.py:88
+#: resources/models/resource.py:89
 msgid "Maximum reservation time"
 msgstr "Pisin varausaika"
 
-#: resources/models/resource.py:91
-msgid "Equipment"
-msgstr ""
-
 #: resources/models/resource.py:92
-msgid "Maximum number of active reservations per user"
-msgstr "Max. varaukset per käyttäjä (voimassa olevat)"
+msgid "Equipment"
+msgstr "Varuste"
 
-#: resources/models/resource.py:96
+#: resources/models/resource.py:93
+msgid "Maximum number of active reservations per user"
+msgstr "Varauksia enintään per käyttäjä (voimassa olevia)"
+
+#: resources/models/resource.py:97
 msgid "resource"
 msgstr "resurssi"
 
-#: resources/models/resource.py:97
+#: resources/models/resource.py:98
 msgid "resources"
 msgstr "resurssit"
 
-#: resources/models/resource.py:128
+#: resources/models/resource.py:129
 msgid "No hours for reservation period"
-msgstr ""
+msgstr "Ajanjaksolla ei ole vapaita tunteja"
 
-#: resources/models/resource.py:135
+#: resources/models/resource.py:136
 msgid "You must end the reservation after it has begun"
-msgstr ""
+msgstr "Varauksen loppuaika ei voi olla ennen alkuaikaa"
 
-#: resources/models/resource.py:137
+#: resources/models/resource.py:138
 msgid "You must start the reservation during opening hours"
-msgstr ""
+msgstr "Varauksen täytyy alkaa aukioloaikojen sisällä"
 
-#: resources/models/resource.py:139
+#: resources/models/resource.py:140
 msgid "You must end the reservation before closing"
-msgstr ""
+msgstr "Varauksen täytyy päättyä ennen sulkemisaikaa"
 
-#: resources/models/resource.py:147
+#: resources/models/resource.py:148
 msgid "The minimum duration for a reservation is "
-msgstr ""
+msgstr "Varauksen minimikesto on "
 
-#: resources/models/resource.py:150
+#: resources/models/resource.py:151
 msgid "The maximum reservation length is "
-msgstr ""
+msgstr "Varauksen maksimikesto on "
 
-#: resources/models/resource.py:155
+#: resources/models/resource.py:156
 msgid "The resource is already reserved for some of the period"
-msgstr ""
-
-#: resources/models/resource.py:302
-#, fuzzy
-#| msgid "Main type"
-msgid "Main photo"
-msgstr "Päätyyppi"
+msgstr "Resurssi on jo varattu ainakin osan ajanjaksosta"
 
 #: resources/models/resource.py:303
-#, fuzzy
-#| msgid "Ground plan URL"
-msgid "Ground plan"
-msgstr "Pohjapiirroksen osoite"
+msgid "Main photo"
+msgstr "Päävalokuva"
 
 #: resources/models/resource.py:304
-msgid "Map"
-msgstr ""
+msgid "Ground plan"
+msgstr "Pohjapiirros"
 
 #: resources/models/resource.py:305
-msgid "Other"
-msgstr ""
+msgid "Map"
+msgstr "Kartta"
 
-#: resources/models/resource.py:309
-msgid "Type"
-msgstr ""
+#: resources/models/resource.py:306
+msgid "Other"
+msgstr "Toinen"
 
 #: resources/models/resource.py:310
-#, fuzzy
-#| msgid "Location"
+msgid "Type"
+msgstr "Tyyppi"
+
+#: resources/models/resource.py:311
 msgid "Caption"
-msgstr "Sijainti"
+msgstr "Kuvateksti"
 
-#: resources/models/resource.py:312
+#: resources/models/resource.py:313
 msgid "Image"
-msgstr ""
-
-#: resources/models/resource.py:314
-msgid "Cropping"
-msgstr ""
+msgstr "Kuva"
 
 #: resources/models/resource.py:315
-msgid "Sort order"
-msgstr ""
+msgid "Cropping"
+msgstr "Rajaus"
 
-#: resources/models/resource.py:383
-#, fuzzy
-#| msgid "resource type"
-msgid "resource image"
-msgstr "resurssityyppi"
+#: resources/models/resource.py:316
+msgid "Sort order"
+msgstr "Järjestysnumero"
 
 #: resources/models/resource.py:384
-#, fuzzy
-#| msgid "resource types"
-msgid "resource images"
-msgstr "resurssityypit"
+msgid "resource image"
+msgstr "resurssin kuva"
 
-#: resources/models/resource.py:402 resources/models/resource.py:403
-#, fuzzy
-#| msgid "resource type"
+#: resources/models/resource.py:385
+msgid "resource images"
+msgstr "resurssin kuvat"
+
+#: resources/models/resource.py:403
+msgctxt "singular"
 msgid "resource equipment"
-msgstr "resurssityyppi"
+msgstr "resurssin varuste"
+
+#: resources/models/resource.py:404
+msgctxt "plural"
+msgid "resource equipment"
+msgstr "resurssin varusteet"
 
 #: resources/models/unit.py:20
 msgid "Time zone"
@@ -497,11 +493,11 @@ msgstr "toimipisteen tunnisteet"
 
 #: resources/templates/admin/resources/period_inline.html:10
 msgid "Add Another"
-msgstr ""
+msgstr "Lisää toinen"
 
 #: resources/templates/admin/resources/period_inline.html:36
 msgid "Delete Item"
-msgstr ""
+msgstr "Poista"
 
 #: respa/settings.py:117 respa/settings_local.py:116
 msgid "Finnish"
@@ -522,6 +518,3 @@ msgstr "RESPA Resurssien varausjärjestelmä"
 #: respa/urls.py:32
 msgid "RESPA Administration"
 msgstr "RESPA Ylläpito"
-
-#~ msgid "Photo URL"
-#~ msgstr "Valokuvan osoite"

--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -2,6 +2,7 @@ import uuid
 import django_filters
 from datetime import datetime
 from django.contrib.auth import get_user_model
+from django.utils.translation import ugettext_lazy as _
 from rest_framework import viewsets, serializers, filters, exceptions, permissions
 from rest_framework.fields import BooleanField
 
@@ -36,6 +37,21 @@ class ReservationSerializer(TranslatedModelSerializer, munigeo_api.GeoModelSeria
             # the view is a list, which means that we are POSTing a new reservation
             reservation = None
         data['begin'], data['end'] = data['resource'].get_reservation_period(reservation, data=data)
+
+        # Check maximum number of active reservations per user per resource.
+        # Only new reservations are taken into account ie. a user can modify an existing reservation
+        # even if it exceeds the limit. (one that was created via admin ui for example)
+        if reservation is None:
+            max_count = data['resource'].max_reservations_per_user
+            if max_count is not None:
+                reservation_count = Reservation.objects.filter(
+                    resource=data['resource'],
+                    user=self.context['request'].user
+                ).active().count()
+                if reservation_count >= max_count:
+                    raise serializers.ValidationError(
+                        _('Maximum number of active reservations for this resource exceeded.')
+                    )
         return data
 
 

--- a/resources/importer/kirjasto10.py
+++ b/resources/importer/kirjasto10.py
@@ -102,6 +102,10 @@ class Kirjasto10Importer(Importer):
                 max_period = datetime.timedelta(minutes=int(60 * float(res_data['Varausaika max'].replace(',', '.'))))
             except ValueError:
                 max_period = None
+            try:
+                max_reservations_per_user = int(res_data['Max. varaukset per tila (voimassa olevat)'])
+            except ValueError:
+                max_reservations_per_user = None
 
             resource_name = self.clean_text(res_data['Nimi'])
 
@@ -112,7 +116,8 @@ class Kirjasto10Importer(Importer):
                 need_manual_confirmation=confirm,
                 min_period=min_period,
                 max_period=max_period,
-                authentication=self.AUTHENTICATION[res_data['Asiakkuus / tunnistamisen tarve']]
+                authentication=self.AUTHENTICATION[res_data['Asiakkuus / tunnistamisen tarve']],
+                max_reservations_per_user=max_reservations_per_user,
             )
             data['name'] = {'fi': resource_name}
             data['description'] = {'fi': self.clean_text(res_data['Kuvaus'])}

--- a/resources/migrations/0020_add_max_reservations_field.py
+++ b/resources/migrations/0020_add_max_reservations_field.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resources', '0019_add_equipment_category'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='resource',
+            name='max_reservations_per_user',
+            field=models.IntegerField(null=True, verbose_name='Maximum number of active reservations per user'),
+        ),
+    ]

--- a/resources/models/equipment.py
+++ b/resources/models/equipment.py
@@ -1,5 +1,6 @@
 from django.contrib.gis.db import models
 from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import pgettext_lazy
 from django.conf import settings
 
 from .base import AutoIdentifiedModel, ModifiableModel
@@ -24,8 +25,8 @@ class Equipment(ModifiableModel, AutoIdentifiedModel):
     category = models.ForeignKey(EquipmentCategory, verbose_name=_('Category'), related_name='equipment')
 
     class Meta:
-        verbose_name = _('equipment')
-        verbose_name_plural = _('equipment')
+        verbose_name = pgettext_lazy('singular', 'equipment')
+        verbose_name_plural = pgettext_lazy('plural', 'equipment')
 
     def __str__(self):
         return get_translated(self, 'name')

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -1,3 +1,4 @@
+from django.utils import timezone
 import django.contrib.postgres.fields as pgfields
 from django.conf import settings
 from django.contrib.gis.db import models
@@ -6,6 +7,11 @@ from psycopg2.extras import DateTimeTZRange
 
 from .base import ModifiableModel
 from .utils import get_dt, save_dt
+
+
+class ReservationQuerySet(models.QuerySet):
+    def active(self):
+        return self.filter(end__gte=timezone.now())
 
 
 class Reservation(ModifiableModel):
@@ -59,6 +65,9 @@ class Reservation(ModifiableModel):
     def get_end_tz(self, tz):
         return self._get_dt("end", tz)
 
+    def is_active(self):
+        return self.end >= timezone.now()
+
     class Meta:
         verbose_name = _("reservation")
         verbose_name_plural = _("reservations")
@@ -71,3 +80,5 @@ class Reservation(ModifiableModel):
         if self.begin and self.end:
             self.duration = DateTimeTZRange(self.begin, self.end)
         return super(Reservation, self).save(*args, **kwargs)
+
+    objects = ReservationQuerySet.as_manager()

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -89,6 +89,8 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
 
     slug = AutoSlugField(populate_from=get_translated_name, unique=True)
     equipment = models.ManyToManyField(Equipment, verbose_name=_('Equipment'), through='ResourceEquipment')
+    max_reservations_per_user = models.IntegerField(verbose_name=_('Maximum number of active reservations per user'),
+                                                    null=True)
 
     class Meta:
         verbose_name = _("resource")

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -10,6 +10,7 @@ from django.core.files.base import ContentFile
 from django.utils import timezone
 from django.utils.six import BytesIO
 from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import pgettext_lazy
 from image_cropping import ImageRatioField
 from PIL import Image
 from autoslug import AutoSlugField
@@ -399,8 +400,8 @@ class ResourceEquipment(ModifiableModel):
     objects = hstore.HStoreGeoManager()
 
     class Meta:
-        verbose_name = _('resource equipment')
-        verbose_name_plural = _('resource equipment')
+        verbose_name = pgettext_lazy('singular', 'resource equipment')
+        verbose_name_plural = pgettext_lazy('plural', 'resource equipment')
 
     def __str__(self):
         return "%s / %s" % (self.equipment, self.resource)

--- a/resources/tests/conftest.py
+++ b/resources/tests/conftest.py
@@ -4,6 +4,7 @@ from rest_framework.test import APIClient, APIRequestFactory
 
 from resources.models import Resource, ResourceType, Unit
 from resources.models import Equipment, EquipmentAlias, ResourceEquipment, EquipmentCategory
+from users.models import User
 
 
 @pytest.fixture
@@ -42,6 +43,7 @@ def resource_in_unit(space_resource_type, test_unit):
         authentication="none",
         name="resource in unit",
         unit=test_unit,
+        max_reservations_per_user=1,
     )
 
 
@@ -78,3 +80,9 @@ def resource_equipment(resource_in_unit, equipment):
         description='test resource equipment',
     )
     return resource_equipment
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def user():
+    return User.objects.create(username='test_user')

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -1,0 +1,100 @@
+import pytest
+from django.utils import dateparse
+from django.utils.encoding import force_text
+from django.core.urlresolvers import reverse
+
+from resources.models import Period, Day, Reservation
+
+
+@pytest.fixture
+def list_url():
+    return reverse('reservation-list')
+
+
+@pytest.mark.django_db
+@pytest.fixture(autouse=True)
+def day_and_period(resource_in_unit):
+    period = Period.objects.create(
+        start='2005-04-01',
+        end='2115-05-01',
+        resource_id=resource_in_unit.id,
+        name='test_period'
+    )
+    Day.objects.create(period=period, weekday=3, opens='08:00', closes='16:00')
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def reservation_data(resource_in_unit):
+    return {
+        'resource': resource_in_unit.pk,
+        'begin': '2115-04-04T11:00:00+02:00',
+        'end': '2115-04-04T12:00:00+02:00'
+    }
+
+
+@pytest.mark.django_db
+def test_reservation_requires_authenticated_user(api_client, list_url, reservation_data):
+    """
+    Tests that an unauthenticated user cannot create a reservation.
+    """
+    response = api_client.post(list_url, data=reservation_data)
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_authenticated_user_can_make_reservation(api_client, list_url, reservation_data, resource_in_unit, user):
+    """
+    Tests that an authenticated user can create a reservation.
+    """
+    api_client.force_authenticate(user=user)
+
+    response = api_client.post(list_url, data=reservation_data)
+    assert response.status_code == 201
+    reservation = Reservation.objects.filter(user=user).latest('created_at')
+    assert reservation.resource == resource_in_unit
+    assert reservation.begin == dateparse.parse_datetime('2115-04-04T11:00:00+02:00')
+    assert reservation.end == dateparse.parse_datetime('2115-04-04T12:00:00+02:00')
+
+
+@pytest.mark.django_db
+def test_reservation_limit_per_user(api_client, list_url, resource_in_unit, reservation_data, user):
+    """
+    Tests that a user cannot exceed her active reservation limit for one resource.
+    """
+
+    # the user already has this reservation
+    Reservation.objects.create(
+        resource=resource_in_unit,
+        begin=dateparse.parse_datetime('2115-04-04T09:00:00+02:00'),
+        end=dateparse.parse_datetime('2115-04-04T10:00:00+02:00'),
+        user=user,
+    )
+    api_client.force_authenticate(user=user)
+
+    # making another reservation should not be possible as the active reservation limit is one
+    response = api_client.post(list_url, data=reservation_data, HTTP_ACCEPT_LANGUAGE='en')
+    assert response.status_code == 400
+    error_messages = [force_text(error_message) for error_message in response.data['non_field_errors']]
+    assert 'Maximum number of active reservations for this resource exceeded.' in error_messages
+
+
+@pytest.mark.django_db
+def test_non_old_reservations_are_excluded(api_client, list_url, resource_in_unit, reservation_data, user):
+    """
+    Tests that a reservation in the past doesn't count when checking reservation limit.
+    """
+
+    # the user already has this reservation which is in the past.
+    Reservation.objects.create(
+        resource=resource_in_unit,
+        begin=dateparse.parse_datetime('2005-04-07T09:00:00+02:00'),
+        end=dateparse.parse_datetime('2005-04-07T10:00:00+02:00'),
+        user=user,
+    )
+    api_client.force_authenticate(user=user)
+
+    # making another reservation should be possible because the other reservation is in the past.
+    response = api_client.post(list_url, data=reservation_data, HTTP_ACCEPT_LANGUAGE='en')
+    assert response.status_code == 201
+


### PR DESCRIPTION
Added a limitation on how many active reservations a user can have on a single resource. The limits are imported from kirjasto data. The limits apply only for reservations created via API.

Also updated localisations and added translations for equipment stuff that was missing.

Refs #63 