### PR TITLE
Fewer reservation limitations for admins

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-11-17 11:39+0200\n"
+"POT-Creation-Date: 2015-11-19 18:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "HH:mm"
 msgstr "TT:mm"
 
-#: resources/api/reservation.py:53
+#: resources/api/reservation.py:57
 msgid "Maximum number of active reservations for this resource exceeded."
 msgstr "Liikaa voimassa olevia varauksia tähän resurssiin."
 
@@ -45,12 +45,12 @@ msgstr "Poikkeusaikavälin kohde"
 msgid "Exceptional period"
 msgstr "Poikkeusaikaväli"
 
-#: resources/models/availability.py:107 resources/models/reservation.py:18
-#: resources/models/resource.py:308
+#: resources/models/availability.py:107 resources/models/reservation.py:19
+#: resources/models/resource.py:289
 msgid "Resource"
 msgstr "Resurssi"
 
-#: resources/models/availability.py:109 resources/models/resource.py:72
+#: resources/models/availability.py:109 resources/models/resource.py:64
 #: resources/models/unit.py:63
 msgid "Unit"
 msgstr "Toimipiste"
@@ -69,12 +69,12 @@ msgstr "Aikavälin kesto"
 
 #: resources/models/availability.py:117 resources/models/equipment.py:12
 #: resources/models/equipment.py:24 resources/models/equipment.py:37
-#: resources/models/resource.py:34 resources/models/resource.py:55
-#: resources/models/resource.py:76 resources/models/unit.py:16
+#: resources/models/resource.py:34 resources/models/resource.py:47
+#: resources/models/resource.py:68 resources/models/unit.py:16
 msgid "Name"
 msgstr "Nimi"
 
-#: resources/models/availability.py:118 resources/models/resource.py:77
+#: resources/models/availability.py:118 resources/models/resource.py:69
 #: resources/models/unit.py:17
 msgid "Description"
 msgstr "Kuvaus"
@@ -205,29 +205,45 @@ msgstr "varusteen toinen nimi"
 msgid "equipment aliases"
 msgstr "varusteen toiset nimet"
 
-#: resources/models/reservation.py:19
+#: resources/models/reservation.py:20
 msgid "Begin time"
 msgstr "Alkuaika"
 
-#: resources/models/reservation.py:20
+#: resources/models/reservation.py:21
 msgid "End time"
 msgstr "Loppuaika"
 
-#: resources/models/reservation.py:21
+#: resources/models/reservation.py:22
 msgid "Length of reservation"
 msgstr "Varauksen kesto"
 
-#: resources/models/reservation.py:23
+#: resources/models/reservation.py:24
 msgid "User"
 msgstr "Käyttäjä"
 
-#: resources/models/reservation.py:72
+#: resources/models/reservation.py:73
 msgid "reservation"
 msgstr "varaus"
 
-#: resources/models/reservation.py:73
+#: resources/models/reservation.py:74
 msgid "reservations"
 msgstr "varaukset"
+
+#: resources/models/reservation.py:81
+msgid "You must end the reservation after it has begun"
+msgstr "Varauksen loppuaika ei voi olla ennen alkuaikaa"
+
+#: resources/models/reservation.py:89
+msgid "Begin and end time must match time slots"
+msgstr "Alku- ja loppuajan täytyy osua aikaikkunoihin"
+
+#: resources/models/reservation.py:92
+msgid "The resource is already reserved for some of the period"
+msgstr "Resurssi on jo varattu ainakin osan ajanjaksosta"
+
+#: resources/models/reservation.py:95
+msgid "The minimum reservation length is %(min_period)s"
+msgstr "Varauksen minimikesto on %(min_period)s"
 
 #: resources/models/resource.py:28
 msgid "Space"
@@ -241,7 +257,7 @@ msgstr "Henkilö"
 msgid "Item"
 msgstr "Esine"
 
-#: resources/models/resource.py:33 resources/models/resource.py:54
+#: resources/models/resource.py:33
 msgid "Main type"
 msgstr "Päätyyppi"
 
@@ -254,179 +270,144 @@ msgid "resource types"
 msgstr "resurssityypit"
 
 #: resources/models/resource.py:46
-msgid "Audiovisual work"
-msgstr "Audiovisuaalinen työskentely"
-
-#: resources/models/resource.py:47
-msgid "Manufacturing"
-msgstr "Fyysisten esineiden tekeminen"
-
-#: resources/models/resource.py:48
-msgid "Watch and listen"
-msgstr "Katselu ja kuuntelu"
-
-#: resources/models/resource.py:49
-msgid "Meet and work"
-msgstr "Kokoontuminen ja työskentely"
+msgid "Parent"
+msgstr ""
 
 #: resources/models/resource.py:50
-msgid "Games"
-msgstr "Pelaaminen"
-
-#: resources/models/resource.py:51
-msgid "Events and exhibitions"
-msgstr "Tapahtumat ja näyttelyt"
-
-#: resources/models/resource.py:58
 msgid "purpose"
 msgstr "käyttötarkoitus"
 
-#: resources/models/resource.py:59
+#: resources/models/resource.py:51
 msgid "purposes"
 msgstr "käyttötarkoitukset"
 
-#: resources/models/resource.py:67
+#: resources/models/resource.py:59
 msgid "None"
 msgstr "Ei mitään"
 
-#: resources/models/resource.py:68
+#: resources/models/resource.py:60
 msgid "Weak"
 msgstr "Heikko"
 
-#: resources/models/resource.py:69
+#: resources/models/resource.py:61
 msgid "Strong"
 msgstr "Vahva"
 
-#: resources/models/resource.py:74
+#: resources/models/resource.py:66
 msgid "Resource type"
 msgstr "Resurssityyppi"
 
-#: resources/models/resource.py:75
+#: resources/models/resource.py:67
 msgid "Purposes"
 msgstr "Käyttötarkoitukset"
 
-#: resources/models/resource.py:78
+#: resources/models/resource.py:70
 msgid "Need manual confirmation"
 msgstr "Tarvitsee virkailijan vahvistuksen"
 
-#: resources/models/resource.py:79
+#: resources/models/resource.py:71
 msgid "Authentication"
 msgstr "Tunnistautuminen"
 
-#: resources/models/resource.py:81
+#: resources/models/resource.py:73
 msgid "People capacity"
 msgstr "Henkilömäärä"
 
-#: resources/models/resource.py:82
+#: resources/models/resource.py:74
 msgid "Area"
 msgstr "Pinta-ala"
 
-#: resources/models/resource.py:85 resources/models/unit.py:19
+#: resources/models/resource.py:77 resources/models/unit.py:19
 msgid "Location"
 msgstr "Sijainti"
 
-#: resources/models/resource.py:87
+#: resources/models/resource.py:79
 msgid "Minimum reservation time"
 msgstr "Lyhin varausaika"
 
-#: resources/models/resource.py:89
+#: resources/models/resource.py:81
 msgid "Maximum reservation time"
 msgstr "Pisin varausaika"
 
-#: resources/models/resource.py:92
+#: resources/models/resource.py:84
 msgid "Equipment"
 msgstr "Varuste"
 
-#: resources/models/resource.py:93
+#: resources/models/resource.py:85
 msgid "Maximum number of active reservations per user"
 msgstr "Varauksia enintään per käyttäjä (voimassa olevia)"
 
-#: resources/models/resource.py:97
+#: resources/models/resource.py:89
 msgid "resource"
 msgstr "resurssi"
 
-#: resources/models/resource.py:98
+#: resources/models/resource.py:90
 msgid "resources"
 msgstr "resurssit"
 
 #: resources/models/resource.py:129
-msgid "No hours for reservation period"
-msgstr "Ajanjaksolla ei ole vapaita tunteja"
+msgid "You cannot make a multi day reservation"
+msgstr "Varaus ei saa ulottua useammalle päivälle"
 
-#: resources/models/resource.py:136
-msgid "You must end the reservation after it has begun"
-msgstr "Varauksen loppuaika ei voi olla ennen alkuaikaa"
+#: resources/models/resource.py:134
+msgid "You must start and end the reservation during opening hours"
+msgstr "Varauksen täytyy alkaa ja päättyä aukioloaikojen sisällä"
 
-#: resources/models/resource.py:138
-msgid "You must start the reservation during opening hours"
-msgstr "Varauksen täytyy alkaa aukioloaikojen sisällä"
+#: resources/models/resource.py:137
+#, python-format
+msgid "The maximum reservation length is %(max_period)s"
+msgstr "Varauksen maksimikesto on %(max_period)s"
 
-#: resources/models/resource.py:140
-msgid "You must end the reservation before closing"
-msgstr "Varauksen täytyy päättyä ennen sulkemisaikaa"
-
-#: resources/models/resource.py:148
-msgid "The minimum duration for a reservation is "
-msgstr "Varauksen minimikesto on "
-
-#: resources/models/resource.py:151
-msgid "The maximum reservation length is "
-msgstr "Varauksen maksimikesto on "
-
-#: resources/models/resource.py:156
-msgid "The resource is already reserved for some of the period"
-msgstr "Resurssi on jo varattu ainakin osan ajanjaksosta"
-
-#: resources/models/resource.py:303
+#: resources/models/resource.py:284
 msgid "Main photo"
 msgstr "Päävalokuva"
 
-#: resources/models/resource.py:304
+#: resources/models/resource.py:285
 msgid "Ground plan"
 msgstr "Pohjapiirros"
 
-#: resources/models/resource.py:305
+#: resources/models/resource.py:286
 msgid "Map"
 msgstr "Kartta"
 
-#: resources/models/resource.py:306
+#: resources/models/resource.py:287
 msgid "Other"
 msgstr "Toinen"
 
-#: resources/models/resource.py:310
+#: resources/models/resource.py:291
 msgid "Type"
 msgstr "Tyyppi"
 
-#: resources/models/resource.py:311
+#: resources/models/resource.py:292
 msgid "Caption"
 msgstr "Kuvateksti"
 
-#: resources/models/resource.py:313
+#: resources/models/resource.py:294
 msgid "Image"
 msgstr "Kuva"
 
-#: resources/models/resource.py:315
+#: resources/models/resource.py:296
 msgid "Cropping"
 msgstr "Rajaus"
 
-#: resources/models/resource.py:316
+#: resources/models/resource.py:297
 msgid "Sort order"
 msgstr "Järjestysnumero"
 
-#: resources/models/resource.py:384
+#: resources/models/resource.py:365
 msgid "resource image"
 msgstr "resurssin kuva"
 
-#: resources/models/resource.py:385
+#: resources/models/resource.py:366
 msgid "resource images"
 msgstr "resurssin kuvat"
 
-#: resources/models/resource.py:403
+#: resources/models/resource.py:384
 msgctxt "singular"
 msgid "resource equipment"
 msgstr "resurssin varuste"
 
-#: resources/models/resource.py:404
+#: resources/models/resource.py:385
 msgctxt "plural"
 msgid "resource equipment"
 msgstr "resurssin varusteet"
@@ -518,3 +499,4 @@ msgstr "RESPA Resurssien varausjärjestelmä"
 #: respa/urls.py:32
 msgid "RESPA Administration"
 msgstr "RESPA Ylläpito"
+

--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -43,19 +43,10 @@ class ReservationSerializer(TranslatedModelSerializer, munigeo_api.GeoModelSeria
         data['resource'].validate_reservation_period(reservation, user, data=data)
 
         # Check maximum number of active reservations per user per resource.
-        # Only new reservations are taken into account ie. a user can modify an existing reservation
-        # even if it exceeds the limit. (one that was created via admin ui for example)
+        # Only new reservations are taken into account ie. a normal user can modify an existing reservation
+        # even if it exceeds the limit. (one that was created via admin ui for example).
         if reservation is None:
-            max_count = data['resource'].max_reservations_per_user
-            if max_count is not None:
-                reservation_count = Reservation.objects.filter(
-                    resource=data['resource'],
-                    user=user
-                ).active().count()
-                if reservation_count >= max_count:
-                    raise serializers.ValidationError(
-                        _('Maximum number of active reservations for this resource exceeded.')
-                    )
+            data['resource'].validate_max_reservations_per_user(user)
 
         # Run model clean
         instance = Reservation(**data)

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -86,13 +86,14 @@ class Reservation(ModifiableModel):
             days = opening_hours.get(dt.date(), [])
             day = next((day for day in days if day['opens'] <= dt <= day['closes']), None)
             if day and not is_valid_time_slot(dt, self.resource.min_period, day['opens']):
-                raise ValidationError(_("Times do not match time slots"))
+                raise ValidationError(_("Begin and end time must match time slots"))
 
         if not self.resource.is_available(self.begin, self.end, self):
             raise ValidationError(_("The resource is already reserved for some of the period"))
 
         if (self.end - self.begin) < self.resource.min_period:
-            raise ValidationError(_("The minimum duration for a reservation is " + str(self.resource.min_period)))
+            raise ValidationError(_("The minimum reservation length is %(min_period)s") %
+                                  {'min_period': self.min_period})
 
     def save(self, *args, **kwargs):
         self.duration = DateTimeTZRange(self.begin, self.end)

--- a/resources/models/utils.py
+++ b/resources/models/utils.py
@@ -56,3 +56,15 @@ def time_to_dtz(time, date=None, arr=None):
             return tz.localize(datetime.datetime(arr.year, arr.month, arr.day, time.hour, time.minute))
     else:
         return None
+
+
+def is_valid_time_slot(time, time_slot_duration, opening_time):
+    """
+    Check if given time is correctly aligned with time slots.
+
+    :type time: datetime.datetime
+    :type time_slot_duration: datetime.timedelta
+    :type opening_time: datetime.datetime
+    :rtype: bool
+    """
+    return not ((time - opening_time) % time_slot_duration)

--- a/resources/tests/conftest.py
+++ b/resources/tests/conftest.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+import datetime
 from rest_framework.test import APIClient, APIRequestFactory
 
 from resources.models import Resource, ResourceType, Unit
@@ -44,6 +45,7 @@ def resource_in_unit(space_resource_type, test_unit):
         name="resource in unit",
         unit=test_unit,
         max_reservations_per_user=1,
+        max_period=datetime.timedelta(hours=2)
     )
 
 

--- a/resources/tests/utils.py
+++ b/resources/tests/utils.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.test.testcases import SimpleTestCase
 from django.utils.six import BytesIO
+from django.utils.encoding import force_text
 from PIL import Image
 
 from resources.models import ResourceImage
@@ -104,7 +105,7 @@ def get_form_data(form, prepared=False):
 
 def check_disallowed_methods(api_client, urls, disallowed_methods):
     """
-    Checks that given urls return http 401 or 405.
+    Check that given urls return http 401 or 405.
 
     :param api_client: API client that executes the requests
     :type api_client: DRF APIClient
@@ -116,3 +117,14 @@ def check_disallowed_methods(api_client, urls, disallowed_methods):
     for url in urls:
         for method in disallowed_methods:
             assert getattr(api_client, method)(url).status_code in (401, 405)
+
+
+def assert_non_field_errors_contain(response, text):
+    """
+    Check if any of the response's non field errors contain the given text.
+
+    :type response: Response
+    :type text: str
+    """
+    error_messages = [force_text(error_message) for error_message in response.data['non_field_errors']]
+    assert any(text in error_message for error_message in error_messages)


### PR DESCRIPTION
Refactored reservation validation logic quite a bit.

Previously reservations were validated in
Resource.get_reservation_period(), which was run also in
Reservation.save(). This caused it to be executed twice when
reservations were created / updated via the API. One more problematic
consequence was that it wasn't able to do any user specific validations,
which are needed now as we should have different restrictions for normal
users and staff members. That old method was also a bit cryptic, and was
probably giving false results on non-trivial reservation cases.

The new implementation tries to address these issues. In it validations
are divided to model level and API level ones. The model level
validations are meant to be common for all resources and they are
located in Reservation.clean().

Model level validations check that:

 * begin time < end time
 * the reservation doesn't overlap other reservations
 * begin time and end time are correctly aligned to match time slots

API level validations check that:

 * normal users cannot make multi day reservations
 * normal users cannot make reservations outside opening hours
 * normal users cannot make reservations longer than max reservation
   period for the resource

In practise API level validations are handled in
Resource.validate_reservation_period(), which replaces the old
get_reservation_period(). One major difference is that while the old
method was also altering begin and end times to match time slots, this
new one does not do that, it just returns an error in case the times
don't match time slots.

Also note that Reservation.clean() is not called in Reservation.save(),
so not even model level validations are run by default when saving an
reservation. In case that is needed for some reason, calling clean()
could be added to save(), but then the validations would be executed
twice, and that cannot be easily fixed.

Changed also max reservation limit check to be not applied to staff 
members, and moved it to it's own method in Resource.

Refs #62 