### PR TITLE
Add reservable field to resource and user_permissions to API

### DIFF
--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -86,6 +86,14 @@ class ResourceSerializer(TranslatedModelSerializer, munigeo_api.GeoModelSerializ
     available_hours = serializers.SerializerMethodField()
     opening_hours = serializers.SerializerMethodField()
     reservations = serializers.SerializerMethodField()
+    user_permissions = serializers.SerializerMethodField()
+
+    def get_user_permissions(self, obj):
+        request = self.context.get('request', None)
+        return {
+            'can_make_reservations': obj.can_make_reservations(request.user) if request else False,
+            'is_admin': obj.is_admin(request.user) if request else False,
+        }
 
     def to_representation(self, obj):
         # we must parse the time parameters before serializing

--- a/resources/importer/kirjasto10.py
+++ b/resources/importer/kirjasto10.py
@@ -50,19 +50,20 @@ class Kirjasto10Importer(Importer):
                 # create parent purpose
                 parent_fi = purp_data[0]
                 parent_en = purp_data[2]
-                parent = Purpose(id=slugify(parent_en))
-                parent.name_fi = parent_fi
-                parent.name_en = parent_en
-                parent.parent = None
-                parent.save()
+                parent, created = Purpose.objects.get_or_create(id=slugify(parent_en), defaults={
+                    'name_fi': parent_fi,
+                    'name_en': parent_en,
+                    'parent': None,
+                })
             # create purpose
             name_fi = purp_data[1]
             name_en = purp_data[3]
-            purpose = Purpose(id=slugify(name_en))
-            purpose.name_fi = name_fi
-            purpose.name_en = name_en
-            purpose.parent = parent
-            purpose.save()
+            purpose, created = Purpose.objects.get_or_create(id=slugify(name_en), defaults={
+                'name_fi': name_fi,
+                'name_en': name_en,
+                'parent': parent,
+            })
+
 
         url = "https://docs.google.com/spreadsheets/d/1mjeCSLQFA82mBvGcbwPkSL3OTZx1kaZtnsq3CF_f4V8/export?format=csv&id=1mjeCSLQFA82mBvGcbwPkSL3OTZx1kaZtnsq3CF_f4V8&gid=0"
         resp = requests.get(url)
@@ -131,9 +132,9 @@ class Kirjasto10Importer(Importer):
                     continue
                 try:
                     purpose_obj = Purpose.objects.get(name_fi=purpose)
+                    data['purposes'].append(purpose_obj)
                 except Purpose.DoesNotExist:
                     print('Purpose %s not found' % purpose)
-                data['purposes'].append(purpose_obj)
 
             res_type_id = self.RESOURCETYPE_IDS[res_data['Tilatyyppi']]
             try:

--- a/resources/importer/kirjasto10.py
+++ b/resources/importer/kirjasto10.py
@@ -109,6 +109,7 @@ class Kirjasto10Importer(Importer):
                 max_reservations_per_user = int(res_data['Max. varaukset per tila (voimassa olevat)'])
             except ValueError:
                 max_reservations_per_user = None
+            reservable = True if res_data['Varattavuus'] == 'Kyllä' else False
 
             resource_name = self.clean_text(res_data['Nimi'])
 
@@ -121,6 +122,7 @@ class Kirjasto10Importer(Importer):
                 max_period=max_period,
                 authentication=self.AUTHENTICATION[res_data['Asiakkuus / tunnistamisen tarve']],
                 max_reservations_per_user=max_reservations_per_user,
+                reservable=reservable,
             )
             data['name'] = {'fi': resource_name}
             data['description'] = {'fi': self.clean_text(res_data['Kuvaus'])}

--- a/resources/migrations/0023_add_reservable.py
+++ b/resources/migrations/0023_add_reservable.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resources', '0022_merge'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='resource',
+            name='reservable',
+            field=models.BooleanField(default=False, verbose_name='Reservable'),
+        ),
+    ]

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -84,6 +84,7 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
     equipment = models.ManyToManyField(Equipment, verbose_name=_('Equipment'), through='ResourceEquipment')
     max_reservations_per_user = models.IntegerField(verbose_name=_('Maximum number of active reservations per user'),
                                                     null=True)
+    reservable = models.BooleanField(verbose_name=_('Reservable'), default=False)
 
     class Meta:
         verbose_name = _("resource")
@@ -294,6 +295,9 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
         # Currently all staff members are allowed to administrate
         # all resources. Will be more finegrained in the future.
         return user.is_staff
+
+    def can_make_reservations(self, user):
+        return self.is_admin(user) or self.reservable
 
 
 class ResourceImage(ModifiableModel):

--- a/resources/tests/conftest.py
+++ b/resources/tests/conftest.py
@@ -45,7 +45,8 @@ def resource_in_unit(space_resource_type, test_unit):
         name="resource in unit",
         unit=test_unit,
         max_reservations_per_user=1,
-        max_period=datetime.timedelta(hours=2)
+        max_period=datetime.timedelta(hours=2),
+        reservable=True,
     )
 
 

--- a/resources/tests/test_resource_api.py
+++ b/resources/tests/test_resource_api.py
@@ -1,0 +1,39 @@
+import pytest
+from django.core.urlresolvers import reverse
+
+
+def _check_permissions_dict(api_client, resource, is_admin, can_make_reservation):
+    """
+    Check that user permissions returned from resource endpoint contain correct values
+    for given user and resource. api_client should have the user authenticated.
+    """
+
+    url = reverse('resource-detail', kwargs={'pk': resource.pk})
+    response = api_client.get(url)
+    assert response.status_code == 200
+    permissions = response.data['user_permissions']
+    assert len(permissions) == 2
+    assert permissions['is_admin'] == is_admin
+    assert permissions['can_make_reservations'] == can_make_reservation
+
+
+@pytest.mark.django_db
+def test_user_permissions_in_resource_endpoint(api_client, resource_in_unit, user):
+    """
+    Tests that resource endpoint returns a permissions dict with correct values.
+    """
+    api_client.force_authenticate(user=user)
+
+    # normal user reservable True, expect is_admin False can_make_reservations True
+    _check_permissions_dict(api_client, resource_in_unit, False, True)
+
+    # normal user reservable False, expect is_admin False can_make_reservations False
+    resource_in_unit.reservable = False
+    resource_in_unit.save()
+    _check_permissions_dict(api_client, resource_in_unit, False, False)
+
+    # staff member reservable False, expect is_admin True can_make_reservations True
+    user.is_staff = True
+    user.save()
+    api_client.force_authenticate(user=user)
+    _check_permissions_dict(api_client, resource_in_unit, True, True)


### PR DESCRIPTION
Added boolean field reservable to Resource and included it in the importer.

Added also user_permissions field to Resource endpoint, which is a
dict read-only containing two boolean values, can_make_reservations and is_admin.

Includes tests.

Contains also fixes to purpose importer.

Refs #67