### PR TITLE
Add user info object to reservation data

### DIFF
--- a/resources/tests/conftest.py
+++ b/resources/tests/conftest.py
@@ -88,4 +88,4 @@ def resource_equipment(resource_in_unit, equipment):
 @pytest.mark.django_db
 @pytest.fixture
 def user():
-    return User.objects.create(username='test_user')
+    return User.objects.create(username='test_user', first_name='Cem', last_name='Kaner', email='cem@kaner.com')

--- a/users/api.py
+++ b/users/api.py
@@ -13,18 +13,13 @@ def register_view(klass, name, base_name=None):
 
 
 class UserSerializer(serializers.ModelSerializer):
-
-    def to_representation(self, obj):
-        ret = super(UserSerializer, self).to_representation(obj)
-        if obj.first_name and obj.last_name:
-            ret['display_name'] = '%s %s' % (obj.first_name, obj.last_name)
-        return ret
+    display_name = serializers.ReadOnlyField(source='get_display_name')
 
     class Meta:
         fields = [
             'last_login', 'username', 'email', 'date_joined',
             'first_name', 'last_name', 'uuid', 'department_name',
-            'is_staff'
+            'is_staff', 'display_name'
         ]
         model = get_user_model()
 

--- a/users/models.py
+++ b/users/models.py
@@ -3,4 +3,5 @@ from helusers.models import AbstractUser
 
 
 class User(AbstractUser):
-    pass
+    def get_display_name(self):
+        return '{0} {1}'.format(self.first_name, self.last_name).strip()


### PR DESCRIPTION
Changed user field in reservation data to an object containing name, email and uuid. It is only shown to staff members. 

The change also affects how reservation user is given in a request, it needs to be "user": {"uuid": <uuid>} instead of just "user": <uuid>. This is relevant after reservation user and request user have been separated.

Refs #70  