### PR TITLE
Fix a bug in reservation editing.

### DIFF
--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -94,7 +94,7 @@ class ReservationSerializer(TranslatedModelSerializer, munigeo_api.GeoModelSeria
 
         # Run model clean
         instance = Reservation(**data)
-        instance.clean()
+        instance.clean(original_reservation=reservation)
 
         return data
 


### PR DESCRIPTION
The existing reservation wasn't taken into account correctly, which
prevented reservation modifying if the new times were overlapping with
the original times.