### PR TITLE
Reservation fixes

### DIFF
--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -56,7 +56,6 @@ class ReservationSerializer(TranslatedModelSerializer, munigeo_api.GeoModelSeria
         fields = ['url', 'id', 'resource', 'user', 'begin', 'end', 'comments', 'is_own']
 
     def validate(self, data):
-        print("validate")
         # if updating a reservation, its identity must be provided to validator
         try:
             reservation = self.context['view'].get_object()

--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -89,15 +89,20 @@ class ReservationSerializer(TranslatedModelSerializer, munigeo_api.GeoModelSeria
         # Check user specific reservation restrictions relating to given period.
         resource.validate_reservation_period(reservation, request_user, data=data)
 
+        if 'comments' in data:
+            if not resource.is_admin(request_user):
+                raise ValidationError(dict(comments=_('Only allowed to be set by staff members')))
+
+        # Mark begin of a critical section. Subsequent calls with this same resource will block here until the first
+        # request is finished. This is needed so that the validations and possible reservation saving are
+        # executed in one block and concurrent requests cannot be validated incorrectly.
+        Resource.objects.select_for_update().get(pk=resource.pk)
+
         # Check maximum number of active reservations per user per resource.
         # Only new reservations are taken into account ie. a normal user can modify an existing reservation
         # even if it exceeds the limit. (one that was created via admin ui for example).
         if reservation is None:
             resource.validate_max_reservations_per_user(request_user)
-
-        if 'comments' in data:
-            if not resource.is_admin(request_user):
-                raise ValidationError(dict(comments=_('Only allowed to be set by staff members')))
 
         # Run model clean
         instance = Reservation(**data)

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -129,10 +129,9 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
 
         if begin.date() != end.date():
             raise ValidationError(_("You cannot make a multi day reservation"))
-
         opening_hours = self.get_opening_hours(begin.date(), end.date())
-        days = opening_hours[begin.date()]
-        if not any(begin >= day['opens'] and end <= day['closes'] for day in days):
+        days = opening_hours.get(begin.date(), None)
+        if days is None or not any(begin >= day['opens'] and end <= day['closes'] for day in days):
             raise ValidationError(_("You must start and end the reservation during opening hours"))
 
         if self.max_period and (end - begin) > self.max_period:

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -377,7 +377,6 @@ def test_reservation_user_filter(api_client, list_url, reservation, resource_in_
 
     # even unauthenticated user should see all the reservations
     response = api_client.get(list_url)
-    print("response data %s" % response.data)
     assert response.data['count'] == 2
 
     # filtering by user

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -135,7 +135,15 @@ def test_normal_user_cannot_make_reservation_outside_open_hours(api_client, list
     """
     api_client.force_authenticate(user=user)
 
+    # invalid day
+    reservation_data['begin'] = '2115-06-01T09:00:00+02:00'
+    reservation_data['end'] = '2115-06-01T10:00:00+02:00'
+    response = api_client.post(list_url, data=reservation_data, HTTP_ACCEPT_LANGUAGE='en')
+    assert response.status_code == 400
+    assert_non_field_errors_contain(response, 'You must start and end the reservation during opening hours')
+
     # valid begin time, end time after closing time
+    reservation_data['begin'] = '2115-04-04T10:00:00+02:00'
     reservation_data['end'] = '2115-04-04T21:00:00+02:00'
     response = api_client.post(list_url, data=reservation_data, HTTP_ACCEPT_LANGUAGE='en')
     assert response.status_code == 400

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -105,6 +105,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',
         'NAME': 'respa',
+        'ATOMIC_REQUESTS': True,
     }
 }
 


### PR DESCRIPTION
Added a critical section which contains some of the reservation
validations and the possible reservation saving. It is implemented by
selecting the resource in question for update, so that it will block
subsequent requests which have the same resource. This is needed so
that concurrent requests cannot be validated incorrectly. Previously it
was possible that multiple requests passed the validation before any of
them was saved.

For the critical section to work it needs to be in a transaction,
so enabled ATOMIC_REQUESTS, which seems to be a good thing for other
stuff as well, atleast for now.

Fixed also a bug in validation, previously if a normal user tried to make a 
reservation with an invalid day the result was an internal server error.