### PR TITLE
Actually humanize durations

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-04 15:14+0200\n"
+"POT-Creation-Date: 2015-12-07 11:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -496,6 +496,20 @@ msgstr "toimipisteen tunniste"
 #: resources/models/unit.py:69
 msgid "unit identifiers"
 msgstr "toimipisteen tunnisteet"
+
+#: resources/models/utils.py:86
+#, python-format
+msgid "%(count)d hour"
+msgid_plural "%(count)d hours"
+msgstr[0] "%(count)d tunti"
+msgstr[1] "%(count)d tuntia"
+
+#: resources/models/utils.py:87
+#, python-format
+msgid "%(count)d minute"
+msgid_plural "%(count)d minutes"
+msgstr[0] "%(count)d minuutti"
+msgstr[1] "%(count)d minuuttia"
 
 #: resources/templates/admin/resources/period_inline.html:10
 msgid "Add Another"

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError
 from psycopg2.extras import DateTimeTZRange
 
 from .base import ModifiableModel
-from .utils import get_dt, save_dt, is_valid_time_slot, humanize_timedelta
+from .utils import get_dt, save_dt, is_valid_time_slot, humanize_duration
 
 
 class ReservationQuerySet(models.QuerySet):
@@ -102,7 +102,7 @@ class Reservation(ModifiableModel):
 
         if (self.end - self.begin) < self.resource.min_period:
             raise ValidationError(_("The minimum reservation length is %(min_period)s") %
-                                  {'min_period': humanize_timedelta(self.min_period)})
+                                  {'min_period': humanize_duration(self.min_period)})
 
     def save(self, *args, **kwargs):
         self.duration = DateTimeTZRange(self.begin, self.end)

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -19,7 +19,7 @@ from django_hstore import hstore
 from resources.errors import InvalidImage
 
 from .base import AutoIdentifiedModel, ModifiableModel
-from .utils import get_translated, get_translated_name, humanize_timedelta
+from .utils import get_translated, get_translated_name, humanize_duration
 from .equipment import Equipment
 
 
@@ -136,7 +136,7 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
 
         if self.max_period and (end - begin) > self.max_period:
             raise ValidationError(_("The maximum reservation length is %(max_period)s") %
-                                  {'max_period': humanize_timedelta(self.max_period)})
+                                  {'max_period': humanize_duration(self.max_period)})
 
     def validate_max_reservations_per_user(self, user):
         """

--- a/resources/models/utils.py
+++ b/resources/models/utils.py
@@ -6,6 +6,8 @@ import time
 import arrow
 from django.conf import settings
 from django.utils import timezone
+from django.utils.translation import ungettext
+
 
 DEFAULT_LANG = settings.LANGUAGES[0][0]
 
@@ -70,5 +72,17 @@ def is_valid_time_slot(time, time_slot_duration, opening_time):
     return not ((time - opening_time) % time_slot_duration)
 
 
-def humanize_timedelta(timedelta):
-    return ':'.join(str(timedelta).split(':')[:2])
+def humanize_duration(duration):
+    """
+    Return the given duration in a localized humanized form.
+
+    Examples: "2 hours 30 minutes", "1 hour", "30 minutes"
+
+    :type duration: datetime.timedelta
+    :rtype: str
+    """
+    hours = duration.days * 24 + duration.seconds // 3600
+    mins = duration.seconds // 60 % 60
+    hours_string = ungettext('%(count)d hour', '%(count)d hours', hours) % {'count': hours} if hours else None
+    mins_string = ungettext('%(count)d minute', '%(count)d minutes', mins) % {'count': mins} if mins else None
+    return ' '.join(filter(None, (hours_string, mins_string)))


### PR DESCRIPTION
The durations are humanized to form "x hour(s) y minutes(s)", examples
"2 hours 30 minutes", "1 hour", "30 minutes".