### PR TITLE
Reservation mails

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-07 11:54+0200\n"
+"POT-Creation-Date: 2015-12-09 10:19+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -55,7 +55,7 @@ msgstr "Poikkeusaikavälin kohde"
 msgid "Exceptional period"
 msgstr "Poikkeusaikaväli"
 
-#: resources/models/availability.py:107 resources/models/reservation.py:19
+#: resources/models/availability.py:107 resources/models/reservation.py:21
 #: resources/models/resource.py:313
 msgid "Resource"
 msgstr "Resurssi"
@@ -215,46 +215,58 @@ msgstr "varusteen toinen nimi"
 msgid "equipment aliases"
 msgstr "varusteen toiset nimet"
 
-#: resources/models/reservation.py:20
+#: resources/models/reservation.py:22
 msgid "Begin time"
 msgstr "Alkuaika"
 
-#: resources/models/reservation.py:21
+#: resources/models/reservation.py:23
 msgid "End time"
 msgstr "Loppuaika"
 
-#: resources/models/reservation.py:22
+#: resources/models/reservation.py:24
 msgid "Length of reservation"
 msgstr "Varauksen kesto"
 
-#: resources/models/reservation.py:25
+#: resources/models/reservation.py:27
 msgid "User"
 msgstr "Käyttäjä"
 
-#: resources/models/reservation.py:74
+#: resources/models/reservation.py:76
 msgid "reservation"
 msgstr "varaus"
 
-#: resources/models/reservation.py:75
+#: resources/models/reservation.py:77
 msgid "reservations"
 msgstr "varaukset"
 
-#: resources/models/reservation.py:89
+#: resources/models/reservation.py:91
 msgid "You must end the reservation after it has begun"
 msgstr "Varauksen loppuaika ei voi olla ennen alkuaikaa"
 
-#: resources/models/reservation.py:97
+#: resources/models/reservation.py:99
 msgid "Begin and end time must match time slots"
 msgstr "Alku- ja loppuajan täytyy osua aikaikkunoihin"
 
-#: resources/models/reservation.py:101
+#: resources/models/reservation.py:103
 msgid "The resource is already reserved for some of the period"
 msgstr "Tila on jo varattu ainakin osan ajanjaksosta"
 
-#: resources/models/reservation.py:104
+#: resources/models/reservation.py:106
 #, python-format
 msgid "The minimum reservation length is %(min_period)s"
 msgstr "Varauksen minimikesto on %(min_period)s"
+
+#: resources/models/reservation.py:113
+msgid "Reservation created"
+msgstr "Varaus luotu"
+
+#: resources/models/reservation.py:122
+msgid "Reservation updated"
+msgstr "Varausta muutettu"
+
+#: resources/models/reservation.py:129
+msgid "Reservation deleted"
+msgstr "Varaus poistettu"
 
 #: resources/models/resource.py:28
 msgid "Space"
@@ -350,13 +362,11 @@ msgstr "Varauksia enintään per käyttäjä (voimassa olevia)"
 
 #: resources/models/resource.py:87
 msgid "Reservable"
-msgstr ""
+msgstr "Varattavissa"
 
 #: resources/models/resource.py:88
-#, fuzzy
-#| msgid "reservation"
 msgid "Reservation info"
-msgstr "varaus"
+msgstr "Varausinfo"
 
 #: resources/models/resource.py:91
 msgid "resource"
@@ -497,14 +507,14 @@ msgstr "toimipisteen tunniste"
 msgid "unit identifiers"
 msgstr "toimipisteen tunnisteet"
 
-#: resources/models/utils.py:86
+#: resources/models/utils.py:89
 #, python-format
 msgid "%(count)d hour"
 msgid_plural "%(count)d hours"
 msgstr[0] "%(count)d tunti"
 msgstr[1] "%(count)d tuntia"
 
-#: resources/models/utils.py:87
+#: resources/models/utils.py:90
 #, python-format
 msgid "%(count)d minute"
 msgid_plural "%(count)d minutes"
@@ -518,6 +528,59 @@ msgstr "Lisää toinen"
 #: resources/templates/admin/resources/period_inline.html:36
 msgid "Delete Item"
 msgstr "Poista"
+
+#: resources/templates/mail/_reservation_data.txt:1
+#, python-format
+msgid "Resource: %(resource)s"
+msgstr "Tila: %(resource)s"
+
+#: resources/templates/mail/_reservation_data.txt:2
+#, python-format
+msgid "Starts: %(begin)s"
+msgstr "Alkaa: %(begin)s"
+
+#: resources/templates/mail/_reservation_data.txt:3
+#, python-format
+msgid "Ends: %(end)s"
+msgstr "Loppuu: %(end)s"
+
+#: resources/templates/mail/base_message.txt:1
+#, python-format
+msgid "Hello %(user_name)s"
+msgstr "Terve %(user_name)s"
+
+#: resources/templates/mail/base_message.txt:4
+msgid "Best regards, the RESPA bot"
+msgstr "Terveisin Respa-automaatti"
+
+#: resources/templates/mail/base_subject.txt:1
+msgid "RESPA"
+msgstr "RESPA"
+
+#: resources/templates/mail/reservation_created_by_admin.txt:1
+msgid "A new reservation has been created for you."
+msgstr "Sinulle on luotu uusi varaus."
+
+#: resources/templates/mail/reservation_deleted_by_admin.txt:1
+msgid "Your reservation has been deleted."
+msgstr "Varauksesi on poistettu."
+
+#: resources/templates/mail/reservation_deleted_by_admin.txt:3
+
+msgid "The deleted reservation:"
+msgstr "Poistettu varaus:"
+
+#: resources/templates/mail/reservation_updated_by_admin.txt:2
+msgid "Your reservation has been modified."
+msgstr "Varaustasi on muutettu."
+
+#: resources/templates/mail/reservation_updated_by_admin.txt:4
+msgid "The new reservation:"
+msgstr "Uusi varaus:"
+
+#: resources/templates/mail/reservation_updated_by_admin.txt:8
+msgid "The old reservation:"
+msgstr "Vanha varaus:"
 
 #: respa/settings.py:118
 msgid "Finnish"

--- a/resources/admin/__init__.py
+++ b/resources/admin/__init__.py
@@ -3,7 +3,7 @@ from django.contrib.admin import site as admin_site
 from django.contrib.gis.admin import OSMGeoAdmin
 from image_cropping import ImageCroppingMixin
 from modeltranslation.admin import TranslationAdmin, TranslationStackedInline
-from .base import CommonExcludeMixin
+from .base import CommonExcludeMixin, PopulateCreatedAndModifiedMixin
 from resources.admin.period_inline import PeriodInline
 from resources.models import Day, Reservation, Resource, ResourceImage, ResourceType, Unit
 from resources.models import Equipment, ResourceEquipment, EquipmentAlias, EquipmentCategory
@@ -17,13 +17,13 @@ class DayInline(admin.TabularInline):
     model = Day
 
 
-class ResourceEquipmentInline(CommonExcludeMixin, TranslationStackedInline):
+class ResourceEquipmentInline(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, TranslationStackedInline):
     model = ResourceEquipment
     fields = ('equipment', 'description', 'data')
     extra = 0
 
 
-class ResourceAdmin(CommonExcludeMixin, TranslationAdmin, HttpsFriendlyGeoAdmin):
+class ResourceAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, TranslationAdmin, HttpsFriendlyGeoAdmin):
     inlines = [
         PeriodInline,
         ResourceEquipmentInline,
@@ -34,7 +34,7 @@ class ResourceAdmin(CommonExcludeMixin, TranslationAdmin, HttpsFriendlyGeoAdmin)
     default_zoom = 12
 
 
-class UnitAdmin(CommonExcludeMixin, TranslationAdmin, HttpsFriendlyGeoAdmin):
+class UnitAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, TranslationAdmin, HttpsFriendlyGeoAdmin):
     inlines = [
         PeriodInline
     ]
@@ -44,36 +44,36 @@ class UnitAdmin(CommonExcludeMixin, TranslationAdmin, HttpsFriendlyGeoAdmin):
     default_zoom = 12
 
 
-class ResourceImageAdmin(CommonExcludeMixin, ImageCroppingMixin, TranslationAdmin):
+class ResourceImageAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, ImageCroppingMixin, TranslationAdmin):
     exclude = ('sort_order', 'image_format')
 
 
-class EquipmentAliasInline(CommonExcludeMixin, admin.TabularInline):
+class EquipmentAliasInline(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, admin.TabularInline):
     model = EquipmentAlias
     readonly_fields = ()
     exclude = CommonExcludeMixin.exclude + ('id',)
     extra = 1
 
 
-class EquipmentAdmin(CommonExcludeMixin, TranslationAdmin):
+class EquipmentAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, TranslationAdmin):
     inlines = (
         EquipmentAliasInline,
     )
 
 
-class ResourceEquipmentAdmin(CommonExcludeMixin, TranslationAdmin):
+class ResourceEquipmentAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, TranslationAdmin):
     fields = ('resource', 'equipment', 'description', 'data')
 
 
-class ReservationAdmin(CommonExcludeMixin, admin.ModelAdmin):
+class ReservationAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, admin.ModelAdmin):
     pass
 
 
-class ResourceTypeAdmin(CommonExcludeMixin, TranslationAdmin):
+class ResourceTypeAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, TranslationAdmin):
     pass
 
 
-class EquipmentCategoryAdmin(TranslationAdmin):
+class EquipmentCategoryAdmin(PopulateCreatedAndModifiedMixin, TranslationAdmin):
     pass
 
 

--- a/resources/admin/base.py
+++ b/resources/admin/base.py
@@ -1,3 +1,11 @@
 class CommonExcludeMixin(object):
     readonly_fields = ('id',)
     exclude = ('created_at', 'created_by', 'modified_at', 'modified_by')
+
+
+class PopulateCreatedAndModifiedMixin(object):
+    def save_model(self, request, obj, form, change):
+        if change is False:
+            obj.created_by = request.user
+        obj.modified_by = request.user
+        obj.save()

--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -181,11 +181,20 @@ class ReservationViewSet(munigeo_api.GeoModelAPIView, viewsets.ModelViewSet):
         kwargs = {'created_by': self.request.user, 'modified_by': self.request.user}
         if 'user' not in serializer.validated_data:
             kwargs['user'] = self.request.user
-        serializer.save(**kwargs)
-
+        instance = serializer.save(**kwargs)
+        if instance.user != self.request.user:
+            instance.send_created_by_admin_mail()
 
     def perform_update(self, serializer):
-        serializer.save(modified_by=self.request.user)
+        old_instance = self.get_object()
+        new_instance = serializer.save(modified_by=self.request.user)
+        if self.request.user != new_instance.user:
+            new_instance.send_updated_by_admin_mail_if_changed(old_instance)
+
+    def perform_destroy(self, instance):
+        instance.delete()
+        if self.request.user != instance.user:
+            instance.send_deleted_by_admin_mail()
 
 
 register_view(ReservationViewSet, 'reservation')

--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -178,10 +178,14 @@ class ReservationViewSet(munigeo_api.GeoModelAPIView, viewsets.ModelViewSet):
     permission_classes = (permissions.IsAuthenticatedOrReadOnly, ReservationPermission)
 
     def perform_create(self, serializer):
-        if 'user' in serializer.validated_data:
-            serializer.save()
-        else:
-            serializer.save(user=self.request.user)
+        kwargs = {'created_by': self.request.user, 'modified_by': self.request.user}
+        if 'user' not in serializer.validated_data:
+            kwargs['user'] = self.request.user
+        serializer.save(**kwargs)
+
+
+    def perform_update(self, serializer):
+        serializer.save(modified_by=self.request.user)
 
 
 register_view(ReservationViewSet, 'reservation')

--- a/resources/models/utils.py
+++ b/resources/models/utils.py
@@ -92,7 +92,7 @@ def humanize_duration(duration):
 
 def send_respa_mail(user, subject, message):
     """
-    Send a mail containing common Respa extras and given content to given user.
+    Send a mail containing common Respa extras and given message to given user.
 
     :type user: User
     :type subject: str

--- a/resources/models/utils.py
+++ b/resources/models/utils.py
@@ -7,6 +7,8 @@ import arrow
 from django.conf import settings
 from django.utils import timezone
 from django.utils.translation import ungettext
+from django.template.loader import render_to_string
+from django.core.mail import send_mail
 
 
 DEFAULT_LANG = settings.LANGUAGES[0][0]
@@ -86,3 +88,16 @@ def humanize_duration(duration):
     hours_string = ungettext('%(count)d hour', '%(count)d hours', hours) % {'count': hours} if hours else None
     mins_string = ungettext('%(count)d minute', '%(count)d minutes', mins) % {'count': mins} if mins else None
     return ' '.join(filter(None, (hours_string, mins_string)))
+
+
+def send_respa_mail(user, subject, message):
+    """
+    Send a mail containing common Respa extras and given content to given user.
+
+    :type user: User
+    :type subject: str
+    :type message: str
+    """
+    final_message = render_to_string('mail/base_message.txt', {'user': user, 'content': message})
+    final_subject = render_to_string('mail/base_subject.txt', {'subject': subject})
+    send_mail(final_subject, final_message, 'info@respa.com', [user.email])

--- a/resources/models/utils.py
+++ b/resources/models/utils.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from django.utils.translation import ungettext
 from django.template.loader import render_to_string
 from django.core.mail import send_mail
+from django.contrib.sites.models import Site
 
 
 DEFAULT_LANG = settings.LANGUAGES[0][0]
@@ -98,6 +99,12 @@ def send_respa_mail(user, subject, message):
     :type subject: str
     :type message: str
     """
+    if not getattr(settings, 'RESPA_MAILS_ENABLED', False):
+        return
+
     final_message = render_to_string('mail/base_message.txt', {'user': user, 'content': message})
     final_subject = render_to_string('mail/base_subject.txt', {'subject': subject})
-    send_mail(final_subject, final_message, 'info@respa.com', [user.email])
+    from_address = (getattr(settings, 'RESPA_MAILS_FROM_ADDRESS', None) or
+                    'noreply@%s' % Site.objects.get_current().domain)
+
+    send_mail(final_subject, final_message, from_address, [user.email])

--- a/resources/templates/mail/_reservation_data.txt
+++ b/resources/templates/mail/_reservation_data.txt
@@ -1,0 +1,3 @@
+{% load i18n %}{% blocktrans with resource=reservation.resource.name %}Resource: {{ resource }}{% endblocktrans %}
+{% blocktrans with begin=reservation.begin %}Starts: {{ begin }}{% endblocktrans %}
+{% blocktrans with end=reservation.end %}Ends: {{ end }}{% endblocktrans %}

--- a/resources/templates/mail/base_message.txt
+++ b/resources/templates/mail/base_message.txt
@@ -1,3 +1,4 @@
 {% load i18n %}{% blocktrans with user_name=user.get_display_name %}Hello {{ user_name }}{% endblocktrans %}
 {{ content }}
+
 {% trans "Best regards, the RESPA bot" %}

--- a/resources/templates/mail/base_message.txt
+++ b/resources/templates/mail/base_message.txt
@@ -1,0 +1,3 @@
+{% load i18n %}{% blocktrans with user_name=user.get_display_name %}Hello {{ user_name }}{% endblocktrans %}
+{{ content }}
+{% trans "Best regards, the RESPA bot" %}

--- a/resources/templates/mail/base_subject.txt
+++ b/resources/templates/mail/base_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% trans "RESPA" %}: {{ subject }}

--- a/resources/templates/mail/reservation_created_by_admin.txt
+++ b/resources/templates/mail/reservation_created_by_admin.txt
@@ -1,0 +1,3 @@
+{% load i18n %}{% trans "A new reservation has been created for you." %}
+
+{% include "mail/_reservation_data.txt" %}

--- a/resources/templates/mail/reservation_deleted_by_admin.txt
+++ b/resources/templates/mail/reservation_deleted_by_admin.txt
@@ -1,0 +1,5 @@
+{% load i18n %}{% trans "Your reservation has been deleted." %}
+
+{% trans "The deleted reservation:" %}
+
+{% include "mail/_reservation_data.txt" %}

--- a/resources/templates/mail/reservation_updated_by_admin.txt
+++ b/resources/templates/mail/reservation_updated_by_admin.txt
@@ -1,0 +1,10 @@
+{% load i18n %}
+{% trans "Your reservation has been modified." %}
+
+{% trans "The new reservation:" %}
+
+{% include "mail/_reservation_data.txt" %}
+
+{% trans "The old reservation:" %}
+
+{% with reservation=old_reservation %}{% include "mail/_reservation_data.txt" %}{% endwith %}

--- a/resources/tests/conftest.py
+++ b/resources/tests/conftest.py
@@ -22,8 +22,6 @@ def staff_api_client(staff_user):
 
 @pytest.fixture
 def user_api_client(user):
-    user.is_staff = True
-    user.save()
     api_client = APIClient()
     api_client.force_authenticate(user=user)
     return api_client
@@ -130,7 +128,8 @@ def staff_user():
         username='test_staff_user',
         first_name='John',
         last_name='Staff',
-        email='john@staff.com'
+        email='john@staff.com',
+        is_staff=True,
     )
 
 

--- a/resources/tests/conftest.py
+++ b/resources/tests/conftest.py
@@ -27,6 +27,14 @@ def user_api_client(user):
     return api_client
 
 
+@pytest.fixture(params=[None, 'user', 'staff_user'])
+def all_user_types_api_client(request):
+    api_client = APIClient()
+    if request.param:
+        api_client.force_authenticate(request.getfuncargvalue(request.param))
+    return api_client
+
+
 @pytest.fixture
 def api_rf():
     return APIRequestFactory()

--- a/resources/tests/test_equipment_api.py
+++ b/resources/tests/test_equipment_api.py
@@ -35,11 +35,11 @@ def _check_keys_and_values(result):
 
 
 @pytest.mark.django_db
-def test_disallowed_methods(staff_api_client, list_url, detail_url):
+def test_disallowed_methods(all_user_types_api_client, list_url, detail_url):
     """
     Tests that only safe methods are allowed to equipment list and detail endpoints.
     """
-    check_only_safe_methods_allowed(staff_api_client, (list_url, detail_url))
+    check_only_safe_methods_allowed(all_user_types_api_client, (list_url, detail_url))
 
 
 @pytest.mark.django_db

--- a/resources/tests/test_equipment_category_api.py
+++ b/resources/tests/test_equipment_category_api.py
@@ -33,11 +33,11 @@ def _check_keys_and_values(result):
 
 
 @pytest.mark.django_db
-def test_disallowed_methods(staff_api_client, list_url, detail_url):
+def test_disallowed_methods(all_user_types_api_client, list_url, detail_url):
     """
     Tests that only safe methods are allowed to equipment list and detail endpoints.
     """
-    check_disallowed_methods(staff_api_client, (list_url, detail_url), UNSAFE_METHODS)
+    check_disallowed_methods(all_user_types_api_client, (list_url, detail_url), UNSAFE_METHODS)
 
 
 @pytest.mark.django_db

--- a/resources/tests/test_purpose_api.py
+++ b/resources/tests/test_purpose_api.py
@@ -19,8 +19,8 @@ def detail_url(purpose):
 
 
 @pytest.mark.django_db
-def test_disallowed_methods(staff_api_client, list_url, detail_url):
+def test_disallowed_methods(all_user_types_api_client, list_url, detail_url):
     """
     Tests that only safe methods are allowed to purpose list and detail endpoints.
     """
-    check_only_safe_methods_allowed(staff_api_client, (list_url, detail_url))
+    check_only_safe_methods_allowed(all_user_types_api_client, (list_url, detail_url))

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -3,6 +3,7 @@ import datetime
 from django.utils import dateparse
 from django.core.urlresolvers import reverse
 from django.core import mail
+from django.test.utils import override_settings
 
 from resources.models import Period, Day, Reservation, Resource
 from .utils import check_disallowed_methods, assert_non_field_errors_contain
@@ -475,6 +476,7 @@ def test_max_reservation_period_error_message(
     assert response.data['non_field_errors'][0] == 'The maximum reservation length is %s' % expected
 
 
+@override_settings(RESPA_MAILS_ENABLED=True)
 @pytest.mark.django_db
 def test_reservation_created_or_deleted_by_admin_mails_sent(
         staff_api_client, list_url, reservation_data, user):
@@ -517,6 +519,7 @@ def test_reservation_created_or_deleted_by_admin_mails_sent(
     ({'end': '2115-04-04T13:00:00+02:00'}, 'Ends: April 4, 2115, 1 p.m.'),
     ({'resource': 'otherresourceid'}, 'Resource: other resource'),
 ])
+@override_settings(RESPA_MAILS_ENABLED=True)
 @pytest.mark.django_db
 def test_reservation_modified_by_admin_mail_sent(
         staff_api_client, reservation_data, user, other_resource, detail_url, input, expected):
@@ -537,6 +540,7 @@ def test_reservation_modified_by_admin_mail_sent(
     assert expected in mail_message
 
 
+@override_settings(RESPA_MAILS_ENABLED=True)
 @pytest.mark.django_db
 def test_reservation_modified_by_admin_mails_not_sent(
         staff_api_client, list_url, reservation, reservation_data, user):

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -64,12 +64,11 @@ def other_resource(space_resource_type, test_unit):
 
 
 @pytest.mark.django_db
-
-def test_disallowed_methods(staff_api_client, list_url):
+def test_disallowed_methods(all_user_types_api_client, list_url):
     """
     Tests that PUT, PATCH and DELETE aren't allowed to reservation list endpoint.
     """
-    check_disallowed_methods(staff_api_client, (list_url, ), ('put', 'patch', 'delete'))
+    check_disallowed_methods(all_user_types_api_client, (list_url, ), ('put', 'patch', 'delete'))
 
 
 @pytest.mark.django_db

--- a/resources/tests/test_resource_api.py
+++ b/resources/tests/test_resource_api.py
@@ -31,11 +31,11 @@ def _check_permissions_dict(api_client, resource, is_admin, can_make_reservation
 
 
 @pytest.mark.django_db
-def test_disallowed_methods(staff_api_client, list_url, detail_url):
+def test_disallowed_methods(all_user_types_api_client, list_url, detail_url):
     """
     Tests that only safe methods are allowed to unit list and detail endpoints.
     """
-    check_only_safe_methods_allowed(staff_api_client, (list_url, detail_url))
+    check_only_safe_methods_allowed(all_user_types_api_client, (list_url, detail_url))
 
 
 @pytest.mark.django_db

--- a/resources/tests/test_resource_type_api.py
+++ b/resources/tests/test_resource_type_api.py
@@ -19,8 +19,8 @@ def detail_url(space_resource):
 
 
 @pytest.mark.django_db
-def test_disallowed_methods(staff_api_client, list_url, detail_url):
+def test_disallowed_methods(all_user_types_api_client, list_url, detail_url):
     """
     Tests that only safe methods are allowed to resource type list and detail endpoints.
     """
-    check_only_safe_methods_allowed(staff_api_client, (list_url, detail_url))
+    check_only_safe_methods_allowed(all_user_types_api_client, (list_url, detail_url))

--- a/resources/tests/test_unit_api.py
+++ b/resources/tests/test_unit_api.py
@@ -19,8 +19,8 @@ def detail_url(test_unit):
 
 
 @pytest.mark.django_db
-def test_disallowed_methods(staff_api_client, list_url, detail_url):
+def test_disallowed_methods(all_user_types_api_client, list_url, detail_url):
     """
     Tests that only safe methods are allowed to unit list and detail endpoints.
     """
-    check_only_safe_methods_allowed(staff_api_client, (list_url, detail_url))
+    check_only_safe_methods_allowed(all_user_types_api_client, (list_url, detail_url))

--- a/resources/tests/test_user_api.py
+++ b/resources/tests/test_user_api.py
@@ -18,8 +18,8 @@ def detail_url(user):
 
 
 @pytest.mark.django_db
-def test_disallowed_methods(staff_api_client, list_url, detail_url):
+def test_disallowed_methods(all_user_types_api_client, list_url, detail_url):
     """
     Tests that only safe methods are allowed to user list and detail endpoints.
     """
-    check_only_safe_methods_allowed(staff_api_client, (list_url, detail_url))
+    check_only_safe_methods_allowed(all_user_types_api_client, (list_url, detail_url))

--- a/resources/tests/utils.py
+++ b/resources/tests/utils.py
@@ -105,7 +105,7 @@ def get_form_data(form, prepared=False):
 
 def check_disallowed_methods(api_client, urls, disallowed_methods):
     """
-    Check that given urls return http 405.
+    Check that given urls return http 405 (or 401 for unauthenticad users)
 
     :param api_client: API client that executes the requests
     :type api_client: DRF APIClient
@@ -114,9 +114,12 @@ def check_disallowed_methods(api_client, urls, disallowed_methods):
     :param disallowed_methods: methods that should ne disallowed
     :type disallowed_methods: tuple [str]
     """
+
+    # endpoints return 401 instead of 405 if there is no user
+    expected_status_codes = (401, 405) if api_client.handler._force_user is None else (405, )
     for url in urls:
         for method in disallowed_methods:
-            assert getattr(api_client, method)(url).status_code == 405
+            assert getattr(api_client, method)(url).status_code in expected_status_codes
 
 
 def check_only_safe_methods_allowed(api_client, urls):

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -194,6 +194,10 @@ THUMBNAIL_PROCESSORS = (
 ) + thumbnail_settings.THUMBNAIL_PROCESSORS
 
 
+RESPA_MAILS_ENABLED = False
+RESPA_MAILS_FROM_ADDRESS = ""
+
+
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.
 f = os.path.join(BASE_DIR, "local_settings.py")


### PR DESCRIPTION
Users need to be notified when their reservations are altered by admins. Emails will now be sent to the users when admins create, modify, or delete reservations for them via the API.

Implemented a generic Django template based mail building system which should make it easy to define new email types using the same base message. The mails are constructed from Django templates living in /resources/templates/mail/ directory.

The Respa mailing is controlled by two settings in the Django settings file:
RESPA_MAILS_ENABLED is used to switch the mailing on / off
RESPA_MAILS_FROM_ADDRESS determines the from address all the mails will use.

The PR also includes somewhat unrelated enhancements to disallowed method testing, the methods are now tested for all user types instead of just staff.

Refs #72