### PR TITLE
Reservation excel files

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-11 12:31+0200\n"
+"POT-Creation-Date: 2015-12-14 14:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,19 +21,27 @@ msgstr ""
 msgid "HH:mm"
 msgstr "TT:mm"
 
-#: resources/api/reservation.py:84
+#: resources/api/reservation.py:88
 #, python-brace-format
 msgid "Object with {slug_name}={value} does not exist."
 msgstr ""
 
-#: resources/api/reservation.py:94
+#: resources/api/reservation.py:98
 msgid "Only allowed to be set by staff members"
 msgstr ""
 
-#: resources/api/reservation.py:135 resources/api/reservation.py:149
+#: resources/api/reservation.py:153 resources/api/reservation.py:167
 #, python-format
 msgid "Invalid value in filter %(filter)s"
 msgstr "Virheellinen arvo filtterissä %(filter)s"
+
+#: resources/api/reservation.py:250 resources/models/reservation.py:77
+msgid "reservations"
+msgstr "varaukset"
+
+#: resources/api/reservation.py:256 resources/models/reservation.py:76
+msgid "reservation"
+msgstr "varaus"
 
 #: resources/apps.py:7
 msgid "Resource app"
@@ -227,17 +235,13 @@ msgstr "Loppuaika"
 msgid "Length of reservation"
 msgstr "Varauksen kesto"
 
+#: resources/models/reservation.py:26
+msgid "Comments"
+msgstr "Kommentit"
+
 #: resources/models/reservation.py:27
 msgid "User"
 msgstr "Käyttäjä"
-
-#: resources/models/reservation.py:76
-msgid "reservation"
-msgstr "varaus"
-
-#: resources/models/reservation.py:77
-msgid "reservations"
-msgstr "varaukset"
 
 #: resources/models/reservation.py:91
 msgid "You must end the reservation after it has begun"
@@ -511,14 +515,14 @@ msgstr "toimipisteen tunniste"
 msgid "unit identifiers"
 msgstr "toimipisteen tunnisteet"
 
-#: resources/models/utils.py:89
+#: resources/models/utils.py:93
 #, python-format
 msgid "%(count)d hour"
 msgid_plural "%(count)d hours"
 msgstr[0] "%(count)d tunti"
 msgstr[1] "%(count)d tuntia"
 
-#: resources/models/utils.py:90
+#: resources/models/utils.py:94
 #, python-format
 msgid "%(count)d minute"
 msgid_plural "%(count)d minutes"

--- a/plain-requirements.txt
+++ b/plain-requirements.txt
@@ -21,3 +21,4 @@ django-autoslug
 djangorestframework-jwt
 pyjwt
 django-hstore
+XlsxWriter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,26 +1,33 @@
-argh==0.26.1
-arrow==0.7.0
-coverage==4.0.2
-defusedxml==0.4.1
 Django==1.8.6
-django-allauth==0.24.1
-django-appconf==1.0.1
-django-autoslug==1.9.3
-django-cors-headers==1.1.0
-django-debug-toolbar==1.4
+django-modeltranslation==0.10.2
+psycopg2==2.6.1
+-e git+https://github.com/City-of-Helsinki/munigeo@414b2665436234428a01816b1654d67063b0e12a#egg=django_munigeo-master
+djangorestframework==3.3.1
 django-filter==0.11.0
 django-grappelli==2.7.2
--e git+https://github.com/City-of-Helsinki/django-helusers.git@111fc5fb2230baef53a2ccd6f29475bfb4d6e3fb#egg=django_helusers-master
-django-hstore==1.4
-django-image-cropping==1.0.2
-django-modeltranslation==0.10.2
-django-mptt==0.7.4
--e git+https://github.com/City-of-Helsinki/munigeo@8bfc04ee2d980b1f4e6002a8ab0079d225cf0e8f#egg=django_munigeo-master
-django-nose==1.4.2
-djangorestframework==3.3.1
-djangorestframework-jwt==1.7.2
-easy-thumbnails==2.2.1
+pytest==2.8.2
+pytest-cov==2.2.0
+pytest-django==2.9.1
 flake8==2.4.1
+arrow==0.7.0
+pytz==2015.7
+coverage==4.0.2
+django-cors-headers==1.1.0
+django-image-cropping==1.0.2
+easy-thumbnails==2.2.1
+-e git+https://github.com/City-of-Helsinki/django-helusers.git@94b0d3db73e76ba5387c7dc0db3c6315ccbbb079#egg=django_helusers-master
+django-allauth==0.24.1
+django-autoslug==1.9.3
+djangorestframework-jwt==1.7.2
+django-hstore==1.4
+XlsxWriter==0.7.7
+## The following requirements were added by pip freeze:
+argh==0.26.1
+defusedxml==0.4.1
+django-appconf==1.0.1
+django-debug-toolbar==1.4
+django-mptt==0.7.4
+django-nose==1.4.2
 mccabe==0.3.1
 nose==1.3.7
 nose-watch==0.9.1
@@ -28,16 +35,11 @@ oauthlib==1.0.3
 pathtools==0.1.2
 pep8==1.5.7
 Pillow==3.0.0
-psycopg2==2.6.1
 py==1.4.30
 pyflakes==0.8.1
 PyJWT==1.4.0
-pytest==2.8.2
-pytest-cov==2.2.0
-pytest-django==2.9.1
 python-dateutil==2.4.2
 python3-openid==3.0.9
-pytz==2015.7
 PyYAML==3.11
 requests==2.8.1
 requests-cache==0.4.10

--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -182,6 +182,18 @@ class ActiveFilterBackend(filters.BaseFilterBackend):
         return queryset
 
 
+class ResourceFilterBackend(filters.BaseFilterBackend):
+    """
+    Filter reservations by resource.
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        resource = request.query_params.get('resource', None)
+        if resource:
+            return queryset.filter(resource__id=resource)
+        return queryset
+
+
 class ReservationPermission(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         if request.method in permissions.SAFE_METHODS or obj.resource.is_admin(request.user):
@@ -209,7 +221,7 @@ class ReservationExcelRenderer(renderers.BaseRenderer):
 class ReservationViewSet(munigeo_api.GeoModelAPIView, viewsets.ModelViewSet):
     queryset = Reservation.objects.all()
     serializer_class = ReservationSerializer
-    filter_backends = (UserFilterBackend, ActiveFilterBackend)
+    filter_backends = (UserFilterBackend, ActiveFilterBackend, ResourceFilterBackend)
     permission_classes = (permissions.IsAuthenticatedOrReadOnly, ReservationPermission)
     renderer_classes = (renderers.JSONRenderer, renderers.BrowsableAPIRenderer, ReservationExcelRenderer)
 

--- a/resources/migrations/0027_comments_verbose_name.py
+++ b/resources/migrations/0027_comments_verbose_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resources', '0026_resource_public'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='reservation',
+            name='comments',
+            field=models.TextField(verbose_name='Comments', blank=True, null=True),
+        ),
+    ]

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -23,7 +23,7 @@ class Reservation(ModifiableModel):
     end = models.DateTimeField(verbose_name=_('End time'))
     duration = pgfields.DateTimeRangeField(verbose_name=_('Length of reservation'), null=True,
                                            blank=True, db_index=True)
-    comments = models.TextField(null=True, blank=True)
+    comments = models.TextField(null=True, blank=True, verbose_name=_('Comments'))
     user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_('User'), null=True,
                              blank=True, db_index=True)
 

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -577,3 +577,29 @@ def test_reservation_modified_by_admin_mails_not_sent(
     response = staff_api_client.put(detail_url, data=reservation_data, format='json')
     assert response.status_code == 200
     assert len(mail.outbox) == 0
+
+
+@pytest.mark.django_db
+def test_reservation_excels(staff_api_client, list_url, detail_url, reservation, user):
+    """
+    Tests that reservation list and detail endpoints return .xlsx files when requested
+    """
+
+    response = staff_api_client.get(
+        list_url,
+        HTTP_ACCEPT='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        HTTP_ACCEPT_LANGUAGE='en',
+    )
+    assert response.status_code == 200
+    assert response._headers['content-disposition'] == ('Content-Disposition', 'attachment; filename=reservations.xlsx')
+    assert len(response.content) > 0
+
+    response = staff_api_client.get(
+        detail_url,
+        HTTP_ACCEPT='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        HTTP_ACCEPT_LANGUAGE='en',
+    )
+    assert response.status_code == 200
+    assert response._headers['content-disposition'] == (
+        'Content-Disposition', 'attachment; filename=reservation-{}.xlsx'.format(reservation.pk))
+    assert len(response.content) > 0


### PR DESCRIPTION
Reservation list and detail endpoints return Excel .xlsx files if
the request's Accept header is to

application/vnd.openxmlformats-officedocument.spreadsheetml.sheet

The .xlsx files contain the same reservations as the endpoints normally
return with fields unit (name), resource (name), begin and end times,
user (email) and comments. User and comments are only added if the
requester has the rights to see those.

Internally the implementation uses the same serializer as before which
makes things a bit more complicated, but it also makes it possible to
use the same field restriction logic for .xlsx files.

Added also resource filter to reservation endpoint.

Refs #86 