### PR TITLE
iCal feed

### DIFF
--- a/plain-requirements.txt
+++ b/plain-requirements.txt
@@ -22,3 +22,4 @@ djangorestframework-jwt
 pyjwt
 django-hstore
 XlsxWriter
+icalendar

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ django-autoslug==1.9.3
 djangorestframework-jwt==1.7.2
 django-hstore==1.4
 XlsxWriter==0.7.7
+icalendar==3.9.1
 ## The following requirements were added by pip freeze:
 argh==0.26.1
 defusedxml==0.4.1

--- a/resources/views/ical.py
+++ b/resources/views/ical.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError, PermissionDenied
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework import renderers
+from rest_framework.reverse import reverse
 from icalendar import Calendar, Event, vDatetime, vText, vGeo
 
 from resources.models import Reservation, Resource
@@ -28,6 +29,15 @@ def build_reservations_ical_file(reservations):
         event['summary'] = vText('{} {}'.format(unit.name, reservation.resource.name))
         cal.add_component(event)
     return cal.to_ical()
+
+
+def build_ical_feed_url(ical_token, request):
+    """
+    Return iCal feed url for given token without query parameters
+    """
+
+    url = reverse('ical-feed', kwargs={'ical_token': ical_token}, request=request)
+    return url[:url.find('?')]
 
 
 class ICalRenderer(renderers.BaseRenderer):

--- a/resources/views/ical.py
+++ b/resources/views/ical.py
@@ -1,0 +1,57 @@
+from django.contrib.auth import get_user_model
+from django.utils.translation import ugettext_lazy as _
+from django.core.exceptions import ValidationError, PermissionDenied
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework import renderers
+from icalendar import Calendar, Event, vDatetime, vText, vGeo
+
+from resources.models import Reservation, Resource
+
+
+def build_reservations_ical_file(reservations):
+    """
+    Return iCalendar file containing given reservations
+    """
+
+    cal = Calendar()
+    cal['X-WR-CALNAME'] = vText('RESPA')
+    cal['name'] = vText('RESPA')
+    for reservation in reservations:
+        event = Event()
+        event['uid'] = 'respa_reservation_{}'.format(reservation.id)
+        event['dtstart'] = vDatetime(reservation.begin)
+        event['dtend'] = vDatetime(reservation.end)
+        unit = reservation.resource.unit
+        event['location'] = vText('{} {} {}'.format(unit.name, unit.street_address, unit.address_zip))
+        event['geo'] = vGeo(unit.location)
+        event['summary'] = vText('{} {}'.format(unit.name, reservation.resource.name))
+        cal.add_component(event)
+    return cal.to_ical()
+
+
+class ICalRenderer(renderers.BaseRenderer):
+    media_type = 'text/calendar'
+    format = 'ics'
+
+    def render(self, data, media_type=None, renderer_context=None):
+        return data.decode(self.charset)
+
+
+class ICalFeedView(APIView):
+    """
+    Fetch a user's reservations in iCalendar format
+    """
+
+    renderer_classes = (ICalRenderer, )
+
+    def get(self, request, ical_token, format=None):
+        User = get_user_model()
+        try:
+            user = User.objects.get(ical_token=ical_token)
+        except User.DoesNotExist:
+            raise PermissionDenied
+        reservations = Reservation.objects.filter(user=user)
+        ical_file = build_reservations_ical_file(reservations)
+        response = Response(ical_file)
+        return response

--- a/resources/views/ical.py
+++ b/resources/views/ical.py
@@ -61,7 +61,7 @@ class ICalFeedView(APIView):
             user = User.objects.get(ical_token=ical_token)
         except User.DoesNotExist:
             raise PermissionDenied
-        reservations = Reservation.objects.filter(user=user)
+        reservations = Reservation.objects.filter(user=user).active()
         ical_file = build_reservations_ical_file(reservations)
         response = Response(ical_file)
         return response

--- a/respa/urls.py
+++ b/respa/urls.py
@@ -21,6 +21,7 @@ from django.utils.translation import ugettext_lazy
 
 from resources.api import RespaAPIRouter
 from resources.views.images import ResourceImageView
+from resources.views.ical import ICalFeedView
 
 # Text to put at the end of each page's <title>.
 admin_site.site_title = ugettext_lazy('RESPA Resource booking system')
@@ -39,6 +40,7 @@ urlpatterns = [
     url(r'^grappelli/', include('grappelli.urls')),
     url(r'^resource_image/(?P<pk>\d+)$', ResourceImageView.as_view(), name='resource-image-view'),
     url(r'^v1/', include(router.urls)),
+    url(r'^v1/reservation/ical/(?P<ical_token>[-\w\d]+).ics$', ICalFeedView.as_view(), name='ical-feed'),
 ]
 
 if settings.DEBUG:

--- a/users/api.py
+++ b/users/api.py
@@ -1,6 +1,8 @@
 from django.contrib.auth import get_user_model
 from rest_framework import permissions, serializers, generics, mixins, viewsets
 
+from resources.views.ical import build_ical_feed_url
+
 
 all_views = []
 
@@ -14,14 +16,18 @@ def register_view(klass, name, base_name=None):
 
 class UserSerializer(serializers.ModelSerializer):
     display_name = serializers.ReadOnlyField(source='get_display_name')
+    ical_feed_url = serializers.SerializerMethodField()
 
     class Meta:
         fields = [
             'last_login', 'username', 'email', 'date_joined',
             'first_name', 'last_name', 'uuid', 'department_name',
-            'is_staff', 'display_name'
+            'is_staff', 'display_name', 'ical_feed_url',
         ]
         model = get_user_model()
+
+    def get_ical_feed_url(self, obj):
+        return build_ical_feed_url(obj.get_or_create_ical_token(), self.context['request'])
 
 
 class UserViewSet(viewsets.ReadOnlyModelViewSet):

--- a/users/migrations/0003_add_ical_token.py
+++ b/users/migrations/0003_add_ical_token.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0002_auto_20151211_1223'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='ical_token',
+            field=models.SlugField(max_length=16, null=True, verbose_name='iCal token', blank=True, unique=True),
+        ),
+    ]

--- a/users/models.py
+++ b/users/models.py
@@ -1,7 +1,18 @@
 from django.db import models
 from helusers.models import AbstractUser
+from django.utils.crypto import get_random_string
 
 
 class User(AbstractUser):
+    ical_token = models.SlugField(
+        max_length=16, null=True, blank=True, unique=True, db_index=True, verbose_name="iCal token"
+    )
+
     def get_display_name(self):
         return '{0} {1}'.format(self.first_name, self.last_name).strip()
+
+    def get_or_create_ical_token(self, recreate=False):
+        if not self.ical_token or recreate:
+            self.ical_token = get_random_string(length=16)
+            self.save()
+        return self.ical_token


### PR DESCRIPTION
Added iCal feed which returns a single user's active reservations in iCal format. Users are given tokens that are used to identify a user when iCal data is requested.

Currently the feed is located at /reservation/ical/<token>.ics, but probably it will be changed to a more RESTful one, /reservation/?format=ics&token=<token> for example.

Refs #89 