### PR TITLE
Prevent manually confirmed reservation cancelling

### DIFF
--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -788,12 +788,15 @@ def test_reservation_can_be_confirmed_with_permission(staff_api_client, staff_us
 
 
 @pytest.mark.django_db
-def test_user_cannot_modify_paid_and_confirmed_reservation(user_api_client, detail_url, reservation,
-                                                           reservation_data_extra, resource_in_unit):
+def test_user_cannot_modify_or_cancel_manually_confirmed_reservation(user_api_client, detail_url, reservation,
+                                                                     reservation_data_extra, resource_in_unit):
     resource_in_unit.need_manual_confirmation = True
     resource_in_unit.save()
 
     response = user_api_client.put(detail_url, data=reservation_data_extra)
+    assert response.status_code == 403
+
+    response = user_api_client.delete(detail_url)
     assert response.status_code == 403
 
 


### PR DESCRIPTION
Also moved the permission check to has_object_permission()

Closes #99 