### PR TITLE
Resource group filters

### DIFF
--- a/resources/api/equipment.py
+++ b/resources/api/equipment.py
@@ -1,5 +1,5 @@
 from rest_framework import viewsets
-
+import django_filters
 from .base import TranslatedModelSerializer, register_view
 from resources.models import Equipment, EquipmentAlias, EquipmentCategory
 
@@ -48,8 +48,19 @@ class EquipmentSerializer(TranslatedModelSerializer):
     category = PlainEquipmentCategorySerializer()
 
 
+class EquipmentFilterSet(django_filters.FilterSet):
+    resource_group = django_filters.Filter(name='resource_equipment__resource__groups__identifier', lookup_expr='in',
+                                           widget=django_filters.widgets.CSVWidget, distinct=True)
+
+    class Meta:
+        model = Equipment
+        fields = ('resource_group',)
+
+
 class EquipmentViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Equipment.objects.all()
     serializer_class = EquipmentSerializer
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
+    filter_class = EquipmentFilterSet
 
 register_view(EquipmentViewSet, 'equipment')

--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -300,7 +300,8 @@ class ResourceFilterSet(django_filters.FilterSet):
     need_manual_confirmation = django_filters.BooleanFilter(name='need_manual_confirmation', widget=DRFFilterBooleanWidget)
     is_favorite = django_filters.BooleanFilter(method='filter_is_favorite', widget=DRFFilterBooleanWidget)
     unit = django_filters.CharFilter(name='unit__id', lookup_expr='iexact')
-    group = django_filters.Filter(name='groups__identifier', lookup_expr='in', widget=django_filters.widgets.CSVWidget)
+    resource_group = django_filters.Filter(name='groups__identifier', lookup_expr='in',
+                                           widget=django_filters.widgets.CSVWidget)
     equipment = django_filters.Filter(name='resource_equipment__equipment__id', lookup_expr='in',
                                       widget=django_filters.widgets.CSVWidget)
 

--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -53,9 +53,20 @@ class ResourceTypeSerializer(TranslatedModelSerializer):
         fields = ['name', 'main_type', 'id']
 
 
+class ResourceTypeFilterSet(django_filters.FilterSet):
+    resource_group = django_filters.Filter(name='resource__groups__identifier', lookup_expr='in',
+                                           widget=django_filters.widgets.CSVWidget, distinct=True)
+
+    class Meta:
+        model = ResourceType
+        fields = ('resource_group',)
+
+
 class ResourceTypeViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = ResourceType.objects.all()
     serializer_class = ResourceTypeSerializer
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
+    filter_class = ResourceTypeFilterSet
 
 register_view(ResourceTypeViewSet, 'type')
 

--- a/resources/api/unit.py
+++ b/resources/api/unit.py
@@ -1,8 +1,18 @@
 from rest_framework import serializers, viewsets
 
+import django_filters
 from munigeo import api as munigeo_api
 from resources.api.base import NullableDateTimeField, TranslatedModelSerializer, register_view
 from resources.models import Unit
+
+
+class UnitFilterSet(django_filters.FilterSet):
+    resource_group = django_filters.Filter(name='resources__groups__identifier', lookup_expr='in',
+                                           widget=django_filters.widgets.CSVWidget, distinct=True)
+
+    class Meta:
+        model = Unit
+        fields = ('resource_group',)
 
 
 class UnitSerializer(TranslatedModelSerializer, munigeo_api.GeoModelSerializer):
@@ -33,6 +43,8 @@ class UnitSerializer(TranslatedModelSerializer, munigeo_api.GeoModelSerializer):
 class UnitViewSet(munigeo_api.GeoModelAPIView, viewsets.ReadOnlyModelViewSet):
     queryset = Unit.objects.all()
     serializer_class = UnitSerializer
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
+    filter_class = UnitFilterSet
 
 
 register_view(UnitViewSet, 'unit')

--- a/resources/tests/test_resource_api.py
+++ b/resources/tests/test_resource_api.py
@@ -331,12 +331,14 @@ def test_resource_group_filter(api_client, resource_in_unit, resource_in_unit2, 
     assert len(response.data['results']) == 3
 
     # one group
-    response = api_client.get('%s?group=%s' % (list_url, resource_group.identifier))
+    response = api_client.get('%s?resource_group=%s' % (list_url, resource_group.identifier))
     assert response.status_code == 200
     assert set(r['id'] for r in response.data['results']) == {resource_in_unit.id}
 
     # multiple groups
-    response = api_client.get('%s?group=%s,%s' % (list_url, resource_group.identifier, resource_group2.identifier))
+    response = api_client.get(
+        '%s?resource_group=%s,%s' % (list_url, resource_group.identifier, resource_group2.identifier)
+    )
     assert response.status_code == 200
     assert set(r['id'] for r in response.data['results']) == {resource_in_unit.id, resource_in_unit2.id}
 

--- a/resources/tests/test_resource_type_api.py
+++ b/resources/tests/test_resource_type_api.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from resources.models import ResourceType
+from resources.models import ResourceGroup, ResourceType
 from django.core.urlresolvers import reverse
 
-from .utils import check_only_safe_methods_allowed
+from .utils import assert_response_objects, check_only_safe_methods_allowed
 
 
 @pytest.fixture
@@ -24,3 +24,50 @@ def test_disallowed_methods(all_user_types_api_client, list_url, detail_url):
     Tests that only safe methods are allowed to resource type list and detail endpoints.
     """
     check_only_safe_methods_allowed(all_user_types_api_client, (list_url, detail_url))
+
+
+@pytest.mark.django_db
+def test_resource_group_filter(api_client, resource_in_unit, resource_in_unit2, resource_in_unit3,
+                               space_resource_type, list_url):
+    type_1 = ResourceType.objects.create(name='test resource type 1')
+    resource_in_unit.type = type_1
+    resource_in_unit.save()
+
+    type_2 = ResourceType.objects.create(name='test resource type 2')
+    resource_in_unit2.type = type_2
+    resource_in_unit2.save()
+
+    type_3 = ResourceType.objects.create(name='test resource type 3')
+    resource_in_unit3.type = type_3
+    resource_in_unit3.save()
+
+    space_resource_type.delete()
+
+    group_1 = ResourceGroup.objects.create(name='test group 1', identifier='test_group_1')
+    resource_in_unit.groups = [group_1]
+
+    group_2 = ResourceGroup.objects.create(name='test group 2', identifier='test_group_2')
+    resource_in_unit2.groups = [group_1, group_2]
+
+    group_3 = ResourceGroup.objects.create(name='test group 3', identifier='test_group_3')
+    resource_in_unit3.groups = [group_3]
+
+    response = api_client.get(list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, (type_1, type_2, type_3))
+
+    response = api_client.get(list_url + '?' + 'resource_group=' + group_1.identifier)
+    assert response.status_code == 200
+    assert_response_objects(response, (type_1, type_2))
+
+    response = api_client.get(list_url + '?' + 'resource_group=' + group_2.identifier)
+    assert response.status_code == 200
+    assert_response_objects(response, type_2)
+
+    response = api_client.get(list_url + '?' + 'resource_group=%s,%s' % (group_2.identifier, group_3.identifier))
+    assert response.status_code == 200
+    assert_response_objects(response, (type_2, type_3))
+
+    response = api_client.get(list_url + '?' + 'resource_group=foobar')
+    assert response.status_code == 200
+    assert len(response.data['results']) == 0

--- a/resources/tests/utils.py
+++ b/resources/tests/utils.py
@@ -188,3 +188,20 @@ def assert_hours(tz, opening_hours, date, opens, closes=None):
         assert hours['closes'] == closes
     else:
         assert hours['closes'] is None
+
+
+def assert_response_objects(response, objects):
+    """
+    Assert object or objects exist in response data.
+    """
+    data = response.data
+    if 'results' in data:
+        data = data['results']
+
+    if not (isinstance(objects, list) or isinstance(objects, tuple)):
+        objects = [objects]
+
+    assert len(objects) == len(data), '%s does not match %s' % (len(objects), len(data))
+    expected_ids = {obj.id for obj in objects}
+    actual_ids = {obj['id'] for obj in data}
+    assert expected_ids == actual_ids, '%s does not match %s' % (expected_ids, actual_ids)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -71,6 +71,11 @@ paths:
 
         Returns 20 units per page. The optional parameter **page** allows specifying page number. **page_size** allows specifying more than 20 units per page.
       parameters:
+        - name: resource_group
+          in: query
+          required: false
+          type: string
+          description: Only return units whose resources belong to the speficied resource group(s). Accepts multiple comma-separated values.
         - name: page
           in: query
           description: Result page number
@@ -181,6 +186,11 @@ paths:
 
         Returns 20 types per page. The optional parameter **page** allows specifying page number. **page_size** allows specifying more than 20 units per page.
       parameters:
+        - name: resource_group
+          in: query
+          required: false
+          type: string
+          description: Only return types for which there are resources that belong to the speficied resource group(s). Accepts multiple comma-separated values.
         - name: page
           in: query
           description: Result page number
@@ -236,6 +246,11 @@ paths:
 
         Returns 20 pieces of equipment per page. The optional parameter **page** allows specifying page number. **page_size** allows specifying more than 20 pieces of equipment per page.
       parameters:
+        - name: resource_group
+          in: query
+          required: false
+          type: string
+          description: Only return pieces of equipment that belong to the speficied resource group(s). Accepts multiple comma-separated values.
         - name: page
           in: query
           description: Result page number
@@ -395,6 +410,11 @@ paths:
           required: false
           type: string
           description: Only return resources that contain the specified piece(s) of equipment. Accepts multiple comma-separated values.
+        - name: resource_group
+          in: query
+          required: false
+          type: string
+          description: Only return resources that belong to the speficied resource group(s). Accepts multiple comma-separated values.
         - name: page
           in: query
           description: Result page number


### PR DESCRIPTION
Added `resource_group` filter to unit, type and equipment API endpoints. The filters accepts multiple comma-separated values similar to the original resource group filter in resource endpoint. 

Also renamed the resource group filter in resource endpoint `group` -> `resource_group`.

Closes #190 