### PR TITLE
Have travis test in Python 3.5 ja 3.7-dev in addition to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,14 @@ dist: trusty
 
 language: python
 python:
+  - '3.5'
   - '3.6'
+  - '3.7-dev'
 
+matrix:
+  allow_failures:
+  - python: 3.7-dev
+  
 cache: pip
 
 # Respa uses int4range (IntegerRangeField) so needs at least Postgres9.2


### PR DESCRIPTION
Ubuntu 16.04 still runs Python 3.5, so we want to test using it as well. It is also useful to see if Python 3.7 is still broken.