### PR TITLE
Add script and instructions for Respa Admin static resources

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/node_modules
+**/*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,12 @@ python:
   - '3.5'
   - '3.6'
   - '3.7-dev'
+node_js: "8.11"
 
 matrix:
   allow_failures:
   - python: 3.7-dev
-  
+
 cache: pip
 
 # Respa uses int4range (IntegerRangeField) so needs at least Postgres9.2
@@ -32,6 +33,7 @@ install: 'pip install codecov -r requirements.txt'
 
 before_script:
   - psql template1 -c 'create extension hstore;'
+  - ./build-resources
 
 script: pytest --cov . resources respa_exchange caterings
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ sudo -u postgres createdb -Orespa respa
 sudo -u postgres psql respa -c "CREATE EXTENSION postgis;"
 ```
 
+### Build Respa Admin static resources
+
+```shell
+./build-resources
+```
+
 ### Run Django migrations and import data
 
 ```shell

--- a/build-resources
+++ b/build-resources
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+rootdir=$(dirname "$0")
+cd "$rootdir/respa_admin"
+yarn
+yarn run build


### PR DESCRIPTION
Add a script for building Respa Admin static resources with Yarn.

Instruct Travis to build the resources with that script.

Add section to README about running that script when setting up a
development environment.

Also add a `.dockerignore` file for ignoring node_modules and *.pyc when
building the Docker image.