### PR TITLE
respa_admin: Implement Tunnistamo login

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ Ready to roll!
   * Failing to do this while setting `GEOS_LIBRARY_PATH`/`GDAL_LIBRARY_PATH` will result in
     "Module not found" errors or similar, which can be annoying to track down.
 
+### Respa Admin authentication
+
+Respa Admin views require logged in user with staff status.  For local
+development you can log in via Django Admin login page to an account
+with staff privileges and use that session to access the Respa Admin.
+
+When accessing the Respa Admin without being logged in, the login
+happens with Tunnistamo.  To test the Tunnistamo login flow in local
+development environment this needs either real Respa app client id and
+client secret in the production Tunnistamo or modifying helusers to use
+local Tunnistamo.  The client id and client secret should be configured
+in Django Admin or shell within a socialaccount.SocialApp instance with
+id "helsinki".  When adding the app to Tunnistamo, the OAuth2 callback
+URL for the app should be something like:
+http://localhost:8000/accounts/helsinki/login/callback/
+
+When the Tunnistamo registration is configured and the login is working,
+then go to Django Admin and set the `is_staff` flag on for the user that
+got created when testing the login.  This allows the user to use the
+Respa Admin.
 
 Production considerations
 -------------------------

--- a/respa_admin/auth.py
+++ b/respa_admin/auth.py
@@ -1,0 +1,31 @@
+from django.conf.urls import url
+from django.contrib.auth.decorators import user_passes_test
+
+
+def admin_url(pattern, view, name):
+    """
+    Define an URL pattern which requires Respa Admin login.
+    """
+    return url(pattern, admin_login_required(view), name=name)
+
+
+def admin_login_required(function):
+    """
+    Decorator which requires login as Respa Admin allowed user.
+    """
+    decorator = user_passes_test(
+        is_allowed_user,
+        login_url='respa_admin:respa-admin-login')
+    return decorator(function)
+
+
+def is_allowed_user(user):
+    """
+    Test if given user is allowed to use Respa Admin.
+
+    :type user: django.contrib.auth.models.AbstractUser
+    :rtype: bool
+    """
+    if not user or not user.is_authenticated or not user.is_active:
+        return False
+    return user.is_staff

--- a/respa_admin/urls.py
+++ b/respa_admin/urls.py
@@ -1,5 +1,6 @@
-from django.conf.urls import include, url
+from django.conf.urls import url as unauthorized_url
 
+from . import views
 from .views.resources import (
     admin_index,
     ResourceListView,
@@ -7,8 +8,10 @@ from .views.resources import (
     admin_office,
     SaveResourceView
 )
+from .auth import admin_url as url
 
 urlpatterns = [
+    unauthorized_url(r'^login/$', views.login, name='respa-admin-login'),
     url(r'^$', admin_index, name='index'),
     url(r'^resources/$', ResourceListView.as_view(), name='resources'),
     url(r'^resource/$', admin_form, name='resource'),

--- a/respa_admin/views/__init__.py
+++ b/respa_admin/views/__init__.py
@@ -1,0 +1,32 @@
+from urllib.parse import urlencode
+
+from django.contrib.auth import logout as auth_logout
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from helusers.providers.helsinki.views import HelsinkiOAuth2Adapter
+
+from ..auth import is_allowed_user
+
+
+def login(request):
+    if request.user and request.user.is_authenticated:
+        # If user is already logged in with unallowed account, then log
+        # out first, to allow re-login with another account.
+        if not is_allowed_user(request.user):
+            return _logout_locally_and_in_tunnistamo(request)
+
+    next_url = request.GET.get('next', None)
+    next_part = ('?' + urlencode({'next': next_url})) if next_url else ''
+    url = reverse('helsinki_login') + next_part
+    return HttpResponseRedirect(url)
+
+
+def _logout_locally_and_in_tunnistamo(request):
+    # First logout locally
+    auth_logout(request)
+
+    # Then logout from Tunnistamo with a redirect which points
+    # back to this view with a given next parameter
+    tunnistamo_url = HelsinkiOAuth2Adapter.profile_url.replace('/user/', '')
+    next_param = urlencode({'next': request.build_absolute_uri()})
+    return HttpResponseRedirect(tunnistamo_url + '/logout/?' + next_param)


### PR DESCRIPTION
Make the Respa Admin views require logged in user with staff status and
to redirect to Tunnistamo login page if such user is not yet logged in
the current session.

For local development, this needs either modifying helusers to use local
Tunnistamo or to configure a development client_id in the "helsinki"
socialaccount.SocialApp instance and that client_id to be registered to
real Tunnistamo with correct callback URL, i.e. something like
http://localhost:8000/accounts/helsinki/login/callback/

When above OAuth2 client_id stuff is sorted out and the login is
working, then set the `is_staff` flag on for the user that got created
when testing the login.  This allows the user to use the Respa Admin.

NOTE: It is also possible to login via regular Django Admin and use that
existing session for authenticating to Respa Admin.