### PR TITLE
Dockerfile: Fix names of installed apt packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 
 ENV APP_NAME respa
 
-RUN apt-get update && apt-get install -y libgdal1h postgresql-client-9.4
+RUN apt-get update && apt-get install -y gdal-bin postgresql-client
 
 COPY requirements.txt .
 COPY deploy/requirements.txt ./deploy/requirements.txt


### PR DESCRIPTION
Install `gdal-bin` instead of `libgdal1h` and install
`postgresql-client` instead of `postgresql-client-9.4`.

This fixes the Docker image to build again with a more recent python:3.5
image, because the packages are upgraded in the newer image and
therefore don't exists with those names with the version specified in
them.