### PR TITLE
Fix couple tests and make Travis run them all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
 matrix:
   allow_failures:
   - python: 3.7-dev
-  
+
 cache: pip
 
 # Respa uses int4range (IntegerRangeField) so needs at least Postgres9.2
@@ -33,7 +33,7 @@ install: 'pip install codecov -r requirements.txt'
 before_script:
   - psql template1 -c 'create extension hstore;'
 
-script: pytest --cov . resources respa_exchange caterings
+script: pytest --cov .
 
 after_success:
   - codecov

--- a/comments/tests/test_comment_api.py
+++ b/comments/tests/test_comment_api.py
@@ -2,6 +2,7 @@ import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.core import mail
+from django.test.utils import override_settings
 from guardian.shortcuts import assign_perm
 
 from caterings.models import CateringOrder
@@ -118,6 +119,7 @@ def test_comment_endpoints_get(user_api_client, user, catering_order_comment, en
     assert data['text'] == 'test catering order comment text'
 
 
+@override_settings(RESPA_MAILS_ENABLED=True)
 @pytest.mark.django_db
 def test_reservation_comment_create(user_api_client, user, staff_user, reservation, new_reservation_comment_data):
     COMMENT_CREATED_BODY = """Target type: {{ target_type }}
@@ -365,6 +367,7 @@ def test_non_commentable_model_comments_hidden(user_api_client, resource_group, 
     assert not response.data['results']
 
 
+@override_settings(RESPA_MAILS_ENABLED=True)
 @pytest.mark.django_db
 def test_catering_order_comment_create(user_api_client, user, staff_user, catering_order,
                                        new_catering_order_comment_data):

--- a/comments/tests/test_comment_api.py
+++ b/comments/tests/test_comment_api.py
@@ -369,8 +369,9 @@ def test_non_commentable_model_comments_hidden(user_api_client, resource_group, 
 
 @override_settings(RESPA_MAILS_ENABLED=True)
 @pytest.mark.django_db
-def test_catering_order_comment_create(user_api_client, user, staff_user, catering_order,
-                                       new_catering_order_comment_data):
+def test_catering_order_comment_create2(
+        user_api_client, user, staff_user, catering_order,
+        new_catering_order_comment_data):
     COMMENT_CREATED_BODY = """Target type: {{ target_type }}
 Created by: {{ created_by.display_name }}
 Created at: {{ created_at|format_datetime }}


### PR DESCRIPTION
Fix the tests in comments app to work by forcing the RESPA_MAILS_ENABLED
to True during the tests and make Travis run all tests rather than just
the tests in resources, respa_exchange and caterings.