### PR TITLE
Move styles from resourceForm.css to main.css

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install: 'pip install codecov -r requirements.txt'
 before_script:
   - psql template1 -c 'create extension hstore;'
   - ./build-resources
+  - ls -l respa_admin/static/dist/main.css  # Check main.css got built
   - ./manage.py compilemessages
 
 script: pytest --cov . --doctest-modules

--- a/respa_admin/static_src/js/resourceFormIndex.js
+++ b/respa_admin/static_src/js/resourceFormIndex.js
@@ -1,4 +1,3 @@
-import '../styles/base.scss';
 import { initializeEventHandlers, setClonableItems }  from './resourceForm';
 
 function start() {

--- a/respa_admin/webpack.config.js
+++ b/respa_admin/webpack.config.js
@@ -9,6 +9,7 @@ const CssRule = {
 
 module.exports = {
   entry: {
+    main: './static_src/styles/base.scss',
     resourceForm: './static_src/js/resourceFormIndex.js',
   },
   output: {


### PR DESCRIPTION
The main CSS file was accidentally renamed to resourceForm.css in commit
a8c413b44.  Fix this by introducing a new bundle for the styles and
removing the style import from the resourceFormIndex.js.