### PR TITLE
Resource periods times

### DIFF
--- a/respa_admin/forms.py
+++ b/respa_admin/forms.py
@@ -22,6 +22,7 @@ from respa.settings import LANGUAGES
 
 class DaysForm(forms.ModelForm):
     opens = forms.TimeField(
+        required=False,
         widget=forms.TimeInput(
             format='%H:%M',
             attrs={'class': 'text-input form-control', 'type': 'time'}
@@ -29,6 +30,7 @@ class DaysForm(forms.ModelForm):
     )
 
     closes = forms.TimeField(
+        required=False,
         widget=forms.TimeInput(
             format='%H:%M',
             attrs={'class': 'text-input form-control', 'type': 'time'}

--- a/respa_admin/forms.py
+++ b/respa_admin/forms.py
@@ -25,7 +25,7 @@ class DaysForm(forms.ModelForm):
         required=False,
         widget=forms.TimeInput(
             format='%H:%M',
-            attrs={'class': 'text-input form-control', 'type': 'time'}
+            attrs={'class': 'text-input form-control'}
         )
     )
 
@@ -33,7 +33,7 @@ class DaysForm(forms.ModelForm):
         required=False,
         widget=forms.TimeInput(
             format='%H:%M',
-            attrs={'class': 'text-input form-control', 'type': 'time'}
+            attrs={'class': 'text-input form-control'}
         )
     )
 

--- a/respa_admin/static_src/js/resourceForm.js
+++ b/respa_admin/static_src/js/resourceForm.js
@@ -1,6 +1,21 @@
-import { addNewImage, removeImage, updateImagesTotalForms } from './resourceFormImages';
-import { addNewPeriod, updateTotalDays, updatePeriodsTotalForms, removePeriod, modifyDays } from './resourceFormPeriods';
-import { toggleLanguage } from './resourceFormLanguage';
+import {
+  addNewImage,
+  removeImage,
+  updateImagesTotalForms,
+} from './resourceFormImages';
+
+import {
+  addNewPeriod,
+  updateTotalDays,
+  updatePeriodsTotalForms,
+  removePeriod,
+  modifyDays,
+  copyTimePeriod,
+} from './resourceFormPeriods';
+
+import {
+  toggleLanguage,
+} from './resourceFormLanguage';
 
 let emptyImageItem = null;
 let emptyPeriodItem = null;
@@ -11,6 +26,7 @@ let emptyDayItem = null;
 * */
 export function initializeEventHandlers() {
   enableNotificationHandler();
+  enableCopyTimePeriod();
   enableAddNewPeriod();
   enableRemovePeriod();
   enableAddDaysByDate();
@@ -71,7 +87,6 @@ function setPeriodAndDayItems() {
     for (let i = 0; i < $periodList.length; i++) {
       let $days = $($periodList[i]).find('#period-days-list');
       $days.children().last().remove();
-      // updatePeriodDaysIndices(i); //TODO: might not be necessary to call this here since it's the last day.
       updateTotalDays(i);
     }
   }
@@ -117,7 +132,7 @@ function enableRemovePeriod() {
 
   for (let i = 0; i < periods.length; i++) {
     let removeButton = document.getElementById('remove-button-' + i);
-    removeButton.addEventListener('click', () => removePeriod(i), false);
+    removeButton.addEventListener('click', () => removePeriod(periods[i]), false);
   }
 }
 
@@ -165,5 +180,17 @@ function enableLanguageButtons() {
     let languageButton = languageSwitcher[0].children[i];
     let language = languageButton.value;
     languageButton.addEventListener('click', () => toggleLanguage(language), false);
+  }
+}
+
+/*
+* Bind event for copying time periods.
+* */
+function enableCopyTimePeriod() {
+  let periods = document.getElementById('current-periods-list').children;
+
+  for (let i = 0; i < periods.length; i++) {
+    let copyButton = document.getElementById('copy-time-period-' + i);
+    copyButton.addEventListener('click', () => copyTimePeriod(periods[i]), false);
   }
 }

--- a/respa_admin/static_src/js/resourceForm.js
+++ b/respa_admin/static_src/js/resourceForm.js
@@ -87,7 +87,7 @@ function setPeriodAndDayItems() {
     for (let i = 0; i < $periodList.length; i++) {
       let $days = $($periodList[i]).find('#period-days-list');
       $days.children().last().remove();
-      updateTotalDays(i);
+      updateTotalDays($($periodList[i]));
     }
   }
 
@@ -144,7 +144,7 @@ function enableAddDaysByDate() {
 
   for (let i = 0; i < periods.length; i++) {
     let $dates = $('#date-inputs-' + i);
-    $dates.change(() => modifyDays($dates[0]));
+    $dates.change(() => modifyDays($(periods[i]), $dates));
   }
 }
 

--- a/respa_admin/templates/common/_periods_accordion.html
+++ b/respa_admin/templates/common/_periods_accordion.html
@@ -9,7 +9,7 @@
                 <span class="panel-heading-period" id="period-timespan"></span>
             </div>
             <div class="right-group">
-                <button class="btn" type="button" id="copy-time-period-{{ id }}">
+                <button class="btn copy-time-btn" type="button" id="copy-time-period-{{ id }}">
                     <span class="glyphicons glyphicons-more-windows icon-left" aria-hidden="true">{% trans "Copy time period" %}</span>
                 </button>
                 <a class="btn" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse{{id}}" aria-expanded="true" aria-controls="#collapse{{id}}">
@@ -31,7 +31,7 @@
                     </div>
                     <div class="form-group">
                         <label class="control-label input-label">{% trans "Time interval" %}</label>
-                        <div class="input-row range-input" id="date-inputs-{{ id }}">
+                        <div class="input-row range-input date-input" id="date-inputs-{{ id }}">
                             {{ period.start }}
                             <span class="glyphicon glyphicon-minus"></span>
                             {{ period.end }}

--- a/respa_admin/templates/common/_periods_accordion.html
+++ b/respa_admin/templates/common/_periods_accordion.html
@@ -9,7 +9,7 @@
                 <span class="panel-heading-period" id="period-timespan"></span>
             </div>
             <div class="right-group">
-                <button class="btn" type="button">
+                <button class="btn" type="button" id="copy-time-period-{{ id }}">
                     <span class="glyphicons glyphicons-more-windows icon-left" aria-hidden="true">{% trans "Copy time period" %}</span>
                 </button>
                 <a class="btn" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse{{id}}" aria-expanded="true" aria-controls="#collapse{{id}}">

--- a/respa_admin/templates/forms/widgets/_checkbox.html
+++ b/respa_admin/templates/forms/widgets/_checkbox.html
@@ -11,6 +11,6 @@
             {% include "django/forms/widgets/attrs.html" %}
         >
 
-        <label for="{{ widget.attrs.id }}" class="checkbox-custom-label input-label">{% trans "Suljettu" %}</label>
+        <label for="{{ widget.attrs.id }}" class="checkbox-custom-label input-label">{% trans "Closed" %}</label>
     </div>
 </div>


### PR DESCRIPTION
Change time fields in period days to be text inputs. Made time fields not required so the user can create a day without adding times (if the day is for instance closed). Refactor some of the Javascript code which is tied to the resource form. Implement the copy periods functionality.