### PR TITLE
respa_admin: Turn on username log-in by default

### DIFF
--- a/respa/settings.py
+++ b/respa/settings.py
@@ -262,7 +262,7 @@ RESPA_COMMENTS_ENABLED = False
 RESPA_DOCX_TEMPLATE = os.path.join(BASE_DIR, 'reports', 'data', 'default.docx')
 
 RESPA_ADMIN_USERNAME_LOGIN = env.bool(
-    'RESPA_ADMIN_USERNAME_LOGIN', default=DEBUG)
+    'RESPA_ADMIN_USERNAME_LOGIN', default=True)
 
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.


### PR DESCRIPTION
Turn on the log-in by username feature by default, because preserving
working Tunnistamo configuration in the Kontena deployment has had some
problems and therefore the username login is a better option for a while.