### PR TITLE
Django admin UI opening hours saving fix

### DIFF
--- a/resources/admin/__init__.py
+++ b/resources/admin/__init__.py
@@ -95,9 +95,9 @@ class ResourceAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, Transla
     list_select_related = ('unit',)
     ordering = ('unit', 'name')
 
-    def save_model(self, request, obj, form, change):
-        super().save_model(request, obj, form, change)
-        obj.update_opening_hours()
+    def save_related(self, request, form, formsets, change):
+        super().save_related(request, form, formsets, change)
+        form.instance.update_opening_hours()
 
 
 class UnitAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, FixedGuardedModelAdminMixin,
@@ -110,9 +110,9 @@ class UnitAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, FixedGuarde
     default_lat = 8438120
     default_zoom = 12
 
-    def save_model(self, request, obj, form, change):
-        super().save_model(request, obj, form, change)
-        obj.update_opening_hours()
+    def save_related(self, request, form, formsets, change):
+        super().save_related(request, form, formsets, change)
+        form.instance.update_opening_hours()
 
 
 class LimitAuthorizedToStaff(admin.ModelAdmin):


### PR DESCRIPTION
Resource opening hours "cache" needs to be rebuild after opening hours change.
Problem was previously that the cache was rebuilt right after a resource or
a unit object was saved, so opening hours objects were not saved yet, because
they are instances of a different model. Now cache rebuilding happens after
also related objects have been saved.