### PR TITLE
Feature/disable sticky top

### DIFF
--- a/respa_admin/static_src/styles/general.scss
+++ b/respa_admin/static_src/styles/general.scss
@@ -4,18 +4,6 @@ h1, h2, h3, h4, h5, h6 {
   margin: 0;
 }
 
-body {
-  position: relative;
-
-  main {
-    margin-top: 120px;
-
-    &.content-without-nav {
-      margin-top: 0;
-    }
-  }
-}
-
 span.glyphicon.icon-left {
   padding-right: $padding-xs-horizontal;
 }

--- a/respa_admin/templates/respa_admin/_base.html
+++ b/respa_admin/templates/respa_admin/_base.html
@@ -26,7 +26,7 @@
         {% endfor %}
     </div>
 
-    <div class='header navbar-fixed-top'>
+    <div class='header navbar-relative-top'>
         {% include "respa_admin/_nav.html" %}
 
         {% if messages %}

--- a/respa_admin/templates/respa_admin/_base.html
+++ b/respa_admin/templates/respa_admin/_base.html
@@ -26,7 +26,7 @@
         {% endfor %}
     </div>
 
-    <div class='header navbar-relative-top'>
+    <div class='header'>
         {% include "respa_admin/_nav.html" %}
 
         {% if messages %}

--- a/respa_admin/templates/respa_admin/login.html
+++ b/respa_admin/templates/respa_admin/login.html
@@ -4,7 +4,7 @@
 {% block page_title %}{% trans "Log in" %}{% endblock page_title %}
 
 {% block body_content %}
-<main class='content-without-nav'>
+<main>
     <section class="hero-section bg-light">
         <div class="container">
             <h1 class="h2">Respa Admin</h1>


### PR DESCRIPTION
Closes #399 

Disabled sticky top by removing `navbar-fixed-top` bootstrap class from header div. Also removed related CSS.