### PR TITLE
Feature/408 filter units

### DIFF
--- a/resources/api/unit.py
+++ b/resources/api/unit.py
@@ -2,13 +2,17 @@ from rest_framework import serializers, viewsets
 
 import django_filters
 from munigeo import api as munigeo_api
-from resources.api.base import NullableDateTimeField, TranslatedModelSerializer, register_view
+from resources.api.base import NullableDateTimeField, TranslatedModelSerializer, register_view, DRFFilterBooleanWidget
 from resources.models import Unit
 
 
 class UnitFilterSet(django_filters.FilterSet):
     resource_group = django_filters.Filter(name='resources__groups__identifier', lookup_expr='in',
                                            widget=django_filters.widgets.CSVWidget, distinct=True)
+    unit_has_resource = django_filters.BooleanFilter(method='filter_unit_has_resource', widget=DRFFilterBooleanWidget)
+
+    def filter_unit_has_resource(self, queryset, name, value):
+        return queryset.exclude(resources__isnull=value)
 
     class Meta:
         model = Unit

--- a/resources/tests/test_unit_api.py
+++ b/resources/tests/test_unit_api.py
@@ -82,3 +82,16 @@ def test_resource_group_filter(api_client, test_unit, test_unit2, test_unit3, re
     response = api_client.get(list_url + '?' + 'resource_group=foobar')
     assert response.status_code == 200
     assert len(response.data['results']) == 0
+
+
+@pytest.mark.django_db
+def test_unit_has_resource_filter(api_client, test_unit,
+                               resource_in_unit2, list_url):
+
+    response = api_client.get(list_url + '?' + 'unit_has_resource=True')
+    assert response.status_code == 200
+    assert_response_objects(response, (resource_in_unit2.unit))
+
+    response = api_client.get(list_url + '?' + 'unit_has_resource=False')
+    assert response.status_code == 200
+    assert_response_objects(response, (test_unit))

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -928,13 +928,11 @@ definitions:
       reservable_max_days_in_advance:
         type: integer
         minimum: 0
-        nullable: true
-        description: 'Reservable max. days in advance'
+        description: 'Reservable max. days in advance, accepts null value'
       reservable_min_days_in_advance:
         type: integer
         minimum: 0
-        nullable: true
-        description: 'Reservable min. days in advance'
+        description: 'Reservable min. days in advance, accepts null value'
       reservations:
         type: array
         description: 'The reservations made for the resource during the queried period'

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -86,6 +86,10 @@ paths:
           description: Number of units per page
           required: false
           type: integer
+        - name: unit_has_resource
+          in: query
+          description: Only return units that either have or do not have related resources, based on the boolean value given.
+          type: boolean
       responses:
         '200':
           description: Successful response


### PR DESCRIPTION
Closes #408, Still requires changes in Varaamo. 

Added a new filter on UnitFilterSet to filter out Units that have no related Resources.

`unit_has_resource` only returns units that either have or do not have related resources, based on the boolean value given.

