### PR TITLE
Fix/407 filter paid resources

### DIFF
--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -323,6 +323,8 @@ class ResourceFilterSet(django_filters.FilterSet):
                                       widget=django_filters.widgets.CSVWidget, distinct=True)
     available_between = django_filters.Filter(method='filter_available_between',
                                               widget=django_filters.widgets.CSVWidget)
+    free_of_charge = django_filters.BooleanFilter(method='filter_free_of_charge',
+                                                  widget=DRFFilterBooleanWidget)
 
     def filter_is_favorite(self, queryset, name, value):
         if not self.user.is_authenticated():
@@ -335,6 +337,12 @@ class ResourceFilterSet(django_filters.FilterSet):
             return queryset.filter(favorited_by=self.user)
         else:
             return queryset.exclude(favorited_by=self.user)
+
+    def filter_free_of_charge(self, queryset, name, value):
+        if value:
+            return queryset.filter(Q(min_price_per_hour__lte=0) | Q(min_price_per_hour__isnull=True))
+        else:
+            return queryset
 
     def _deserialize_datetime(self, value):
         try:
@@ -466,7 +474,7 @@ class ResourceFilterSet(django_filters.FilterSet):
 
     class Meta:
         model = Resource
-        fields = ['purpose', 'type', 'people', 'need_manual_confirmation', 'is_favorite', 'unit', 'available_between']
+        fields = ['purpose', 'type', 'people', 'need_manual_confirmation', 'is_favorite', 'unit', 'available_between', 'min_price_per_hour']
 
 
 class ResourceFilterBackend(filters.BaseFilterBackend):

--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -339,10 +339,11 @@ class ResourceFilterSet(django_filters.FilterSet):
             return queryset.exclude(favorited_by=self.user)
 
     def filter_free_of_charge(self, queryset, name, value):
+        qs = Q(min_price_per_hour__lte=0) | Q(min_price_per_hour__isnull=True)
         if value:
-            return queryset.filter(Q(min_price_per_hour__lte=0) | Q(min_price_per_hour__isnull=True))
+            return queryset.filter(qs)
         else:
-            return queryset
+            return queryset.exclude(qs)
 
     def _deserialize_datetime(self, value):
         try:

--- a/resources/tests/test_resource_api.py
+++ b/resources/tests/test_resource_api.py
@@ -694,4 +694,4 @@ def test_filtering_free_of_charge(list_url, api_client, resource_in_unit,
 
     response = api_client.get('{0}?free_of_charge=false'.format(list_url))
     assert response.status_code == 200
-    assert_response_objects(response, [free_resource, free_resource2, not_free_resource])
+    assert_response_objects(response, not_free_resource)

--- a/resources/tests/test_resource_api.py
+++ b/resources/tests/test_resource_api.py
@@ -674,3 +674,24 @@ def test_available_between_with_period(list_url, resource_in_unit, resource_in_u
     response = user_api_client.get(list_url, params)
     assert response.status_code == 200
     assert_response_objects(response, expected_resources)
+
+
+@pytest.mark.django_db
+def test_filtering_free_of_charge(list_url, api_client, resource_in_unit,
+                                  resource_in_unit2, resource_in_unit3):
+    free_resource = resource_in_unit
+    free_resource2 = resource_in_unit2
+    not_free_resource = resource_in_unit3
+
+    free_resource.min_price_per_hour = 0
+    free_resource.save()
+    not_free_resource.min_price_per_hour = 9001
+    not_free_resource.save()
+
+    response = api_client.get('{0}?free_of_charge=true'.format(list_url))
+    assert response.status_code == 200
+    assert_response_objects(response, [free_resource, free_resource2])
+
+    response = api_client.get('{0}?free_of_charge=false'.format(list_url))
+    assert response.status_code == 200
+    assert_response_objects(response, [free_resource, free_resource2, not_free_resource])

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -460,6 +460,11 @@ paths:
           required: false
           type: number
           description: Use together with `lat` and `long`. Returns only resources that are within the given `distance` of the point which is calculated from `lat` and `lon`.
+        - name: free_of_charge
+          in: query
+          required: false
+          type: boolean
+          description: If given boolean is `true`, returns only resources that have their `min_price_per_hour` value of `0` or `None`. If given boolean is `false`, returns all resources.  
       responses:
         '200':
           description: Successful response

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -464,7 +464,7 @@ paths:
           in: query
           required: false
           type: boolean
-          description: If given boolean is `true`, returns only resources that have their `min_price_per_hour` value of `0` or `None`. If given boolean is `false`, returns all resources.  
+          description: If given boolean is `true`, returns only resources that have their `min_price_per_hour` value of `0` or `None`. If given boolean is `false`, returns resources that have their `min_price_per_hour` greater than 0.  
       responses:
         '200':
           description: Successful response


### PR DESCRIPTION
Closes #407 

Implemented a boolean filter `free_of_charge` for `/resource` endpoint.

`free_of_charge=true` returns resources that have their `min_price_per_hour` value of `0` or `None`, as in not set.

`free_of_charge=false` returns all resources, as this is the default parameter and value in Varaamo requests.