### PR TITLE
Fix None value resource type or unit

### DIFF
--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -43,8 +43,8 @@ class ResourceListView(ListView):
         context['units'] = Unit.objects.filter(
             pk__in=resources.values('unit'))
         context['search_query'] = self.search_query
-        context['selected_resource_type'] = self.resource_type
-        context['selected_resource_unit'] = self.resource_unit
+        context['selected_resource_type'] = self.resource_type or ''
+        context['selected_resource_unit'] = self.resource_unit or ''
         return context
 
     def get_unfiltered_queryset(self):


### PR DESCRIPTION
Closes #431 

If no value of `self.resource_type` or `self.resource_unit` is found during `get_context_data()`, pass empty string to template context variables, instead of `None`