### PR TITLE
Change translation

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -977,7 +977,7 @@ msgid "Additional information before calendar."
 msgstr "Lisätiedot ennen kalenteria."
 
 msgid "E-mail notifications"
-msgstr "Sähköposti ilmoitukset"
+msgstr "Sähköposti-ilmoitukset"
 
 msgid "A notification will be sent when a space is booked."
 msgstr "Ilmoitus lähetetään, kun tilaa varataan."


### PR DESCRIPTION
Closes #392 

It turns out that the majority of missing translations come from external libraries. @petterill suggested that we won't use time to fix them at this point.

Changed line `sähköposti ilmoitukset` into `sähköposti-ilmoitukset`.