### PR TITLE
Change button type to submit instead of button

### DIFF
--- a/respa_admin/templates/respa_admin/page_resources.html
+++ b/respa_admin/templates/respa_admin/page_resources.html
@@ -20,7 +20,7 @@
                             <span class="input-group-addon">{% trans 'Search' %}</span>
                             <input autofocus type="text" class="form-control text-input" name="search_query" value="{{ request.GET.search_query }}">
                             <span class="input-group-btn">
-                                <button class="btn btn-default" type="button">
+                                <button class="btn btn-default" type="submit">
                                     <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
                                 </button>
                             </span>


### PR DESCRIPTION
Closes #448 

Changed button type to `submit` instead of `button`.