### PR TITLE
Implement order by functionality

### DIFF
--- a/respa_admin/static_src/styles/page-resource.scss
+++ b/respa_admin/static_src/styles/page-resource.scss
@@ -1,3 +1,10 @@
+.order-by-link {
+  background-color: #ebebeb;
+  &:hover {
+    background-color: #fff;
+  }
+}
+
 .headline {
 
   & > * {

--- a/respa_admin/templates/respa_admin/common/_pagination.html
+++ b/respa_admin/templates/respa_admin/common/_pagination.html
@@ -6,7 +6,7 @@
                     <a
                         aria-label="Previous"
                         class="btn previous"
-                        href="?page={{ page_obj.previous_page_number }}&resource_type={{ selected_resource_type }}&resource_unit={{ selected_resource_unit }}"
+                        href="?page={{ page_obj.previous_page_number }}&resource_type={{ selected_resource_type }}&resource_unit={{ selected_resource_unit }}&order_by={{ order_by }}"
                     >
                         <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
                     </a>
@@ -17,7 +17,7 @@
                     <li>
                         <a
                             class="btn {% if page_no == page_obj.number %}active-page{% endif %}"
-                            href="?page={{ page_no }}&resource_type={{ selected_resource_type }}&resource_unit={{ selected_resource_unit }}"
+                            href="?page={{ page_no }}&resource_type={{ selected_resource_type }}&resource_unit={{ selected_resource_unit }}&order_by={{ order_by }}"
                         >
                             {{ page_no }}
                         </a>
@@ -26,7 +26,7 @@
                     <li>
                         <a
                             class="btn"
-                            href="?page={{ page_no }}&resource_type={{ selected_resource_type }}&resource_unit={{ selected_resource_unit }}"
+                            href="?page={{ page_no }}&resource_type={{ selected_resource_type }}&resource_unit={{ selected_resource_unit }}&order_by={{ order_by }}"
                         >
                             ...
                         </a>
@@ -38,7 +38,7 @@
                     <a
                         aria-label="Next"
                         class="btn next"
-                        href="?page={{ page_obj.next_page_number }}&resource_type={{ selected_resource_type }}&resource_unit={{ selected_resource_unit }}"
+                        href="?page={{ page_obj.next_page_number }}&resource_type={{ selected_resource_type }}&resource_unit={{ selected_resource_unit }}&order_by={{ order_by }}"
                     >
                         <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
                     </a>

--- a/respa_admin/templates/respa_admin/resources/_resource_list.html
+++ b/respa_admin/templates/respa_admin/resources/_resource_list.html
@@ -63,15 +63,15 @@
             <ul class='list-group'>
                 <li class="list-group-item sort-bar">
                     <div class='pull-left empty-holder col-1'></div>
-                    <button class="col-2 btn">
-                        {% trans 'Name' %} <span class='glyphicon glyphicon-sort' aria-hidden="true"></span>
-                    </button>
-                    <button class="col-3 btn">
-                        {% trans 'Availability' %} <span class='glyphicon glyphicon-sort' aria-hidden="true"></span>
-                    </button>
-                    <button class="col-4 btn">
-                        {% trans 'Visibility' %} <span class='glyphicon glyphicon-sort' aria-hidden="true"></span>
-                    </button>
+                        <a class="col-2 btn order-by-link" href="?order_by={% if order_by == 'name' %}-name{% else %}name{% endif %}">
+                            {% trans 'Name' %} <span class='glyphicon glyphicon-sort' aria-hidden="true"></span>
+                        </a>
+                        <a class="col-3 btn order-by-link" href="?order_by={% if order_by == 'reservable' %}-reservable{% else %}reservable{% endif %}">
+                            {% trans 'Availability' %} <span class='glyphicon glyphicon-sort' aria-hidden="true"></span>
+                        </a>
+                        <a class="col-4 btn order-by-link" href="?order_by={% if order_by == 'public' %}-public{% else %}public{% endif %}">
+                            {% trans 'Visibility' %} <span class='glyphicon glyphicon-sort' aria-hidden="true"></span>
+                        </a>
                 </li>
                 {% for resource in resources %}
                     <li class="list-group-item">

--- a/respa_admin/templates/respa_admin/resources/_resource_list.html
+++ b/respa_admin/templates/respa_admin/resources/_resource_list.html
@@ -63,13 +63,13 @@
             <ul class='list-group'>
                 <li class="list-group-item sort-bar">
                     <div class='pull-left empty-holder col-1'></div>
-                        <a class="col-2 btn order-by-link" href="?order_by={% if order_by == 'name' %}-name{% else %}name{% endif %}">
+                        <a class="col-2 btn order-by-link" href="?resource_type={{ selected_resource_type }}&resource_unit={{ selected_resource_unit }}&order_by={% if order_by == 'name' %}-name{% else %}name{% endif %}">
                             {% trans 'Name' %} <span class='glyphicon glyphicon-sort' aria-hidden="true"></span>
                         </a>
-                        <a class="col-3 btn order-by-link" href="?order_by={% if order_by == 'reservable' %}-reservable{% else %}reservable{% endif %}">
+                        <a class="col-3 btn order-by-link" href="?resource_type={{ selected_resource_type }}&resource_unit={{ selected_resource_unit }}&order_by={% if order_by == 'reservable' %}-reservable{% else %}reservable{% endif %}">
                             {% trans 'Availability' %} <span class='glyphicon glyphicon-sort' aria-hidden="true"></span>
                         </a>
-                        <a class="col-4 btn order-by-link" href="?order_by={% if order_by == 'public' %}-public{% else %}public{% endif %}">
+                        <a class="col-4 btn order-by-link" href="?resource_type={{ selected_resource_type }}&resource_unit={{ selected_resource_unit }}&order_by={% if order_by == 'public' %}-public{% else %}public{% endif %}">
                             {% trans 'Visibility' %} <span class='glyphicon glyphicon-sort' aria-hidden="true"></span>
                         </a>
                 </li>

--- a/respa_admin/tests/conftest.py
+++ b/respa_admin/tests/conftest.py
@@ -7,6 +7,10 @@ from resources.tests.conftest import (
     space_resource_type,
     terms_of_use,
     test_unit,
+    test_unit2,
+    general_admin,
+    resource_in_unit,
+    resource_in_unit2,
 )
 
 

--- a/respa_admin/tests/test_queryset.py
+++ b/respa_admin/tests/test_queryset.py
@@ -1,0 +1,62 @@
+import pytest
+from django.core.urlresolvers import reverse
+
+from ..views.resources import ResourceListView
+
+url = reverse('respa_admin:index')
+
+
+@pytest.mark.django_db
+def test_order_by_name(rf, general_admin, resource_in_unit, resource_in_unit2):
+    resource_in_unit.unit.name = 'aaaaa'
+    resource_in_unit.unit.save()
+    resource_in_unit2.unit.name = 'bbbbb'
+    resource_in_unit2.unit.save()
+
+    request = rf.get(url + '?order_by=name')
+    request.user = general_admin
+    response = ResourceListView.as_view()(request)
+    resources = response.context_data.get('resources')
+    assert resources[0] == resource_in_unit
+
+    request = rf.get(url + '?order_by=-name')
+    request.user = general_admin
+    response = ResourceListView.as_view()(request)
+    resources = response.context_data.get('resources')
+    assert resources[0] == resource_in_unit2
+
+
+@pytest.mark.django_db
+def test_order_by_reservable(rf, general_admin, resource_in_unit, resource_in_unit2):
+    resource_in_unit2.reservable = False
+    resource_in_unit2.save()
+
+    request = rf.get(url + '?order_by=reservable')
+    request.user = general_admin
+    response = ResourceListView.as_view()(request)
+    resources = response.context_data.get('resources')
+    assert resources[0] == resource_in_unit2
+
+    request = rf.get(url + '?order_by=-reservable')
+    request.user = general_admin
+    response = ResourceListView.as_view()(request)
+    resources = response.context_data.get('resources')
+    assert resources[0] == resource_in_unit
+
+
+@pytest.mark.django_db
+def test_order_by_public(rf, general_admin, resource_in_unit, resource_in_unit2):
+    resource_in_unit2.public = False
+    resource_in_unit2.save()
+
+    request = rf.get(url + '?order_by=public')
+    request.user = general_admin
+    response = ResourceListView.as_view()(request)
+    resources = response.context_data.get('resources')
+    assert resources[0] == resource_in_unit2
+
+    request = rf.get(url + '?order_by=-public')
+    request.user = general_admin
+    response = ResourceListView.as_view()(request)
+    resources = response.context_data.get('resources')
+    assert resources[0] == resource_in_unit

--- a/respa_admin/tests/test_queryset.py
+++ b/respa_admin/tests/test_queryset.py
@@ -8,10 +8,10 @@ url = reverse('respa_admin:index')
 
 @pytest.mark.django_db
 def test_order_by_name(rf, general_admin, resource_in_unit, resource_in_unit2):
-    resource_in_unit.unit.name = 'aaaaa'
-    resource_in_unit.unit.save()
-    resource_in_unit2.unit.name = 'bbbbb'
-    resource_in_unit2.unit.save()
+    resource_in_unit.name = 'aaaaa'
+    resource_in_unit.save()
+    resource_in_unit2.name = 'bbbbb'
+    resource_in_unit2.save()
 
     request = rf.get(url + '?order_by=name')
     request.user = general_admin

--- a/respa_admin/tests/test_queryset.py
+++ b/respa_admin/tests/test_queryset.py
@@ -1,5 +1,5 @@
 import pytest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from ..views.resources import ResourceListView
 

--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -65,8 +65,9 @@ class ResourceListView(ListView):
         if self.resource_unit:
             qs = qs.filter(unit=self.resource_unit)
         if self.order_by:
+            order_by_param = self.order_by.strip('-')
             try:
-                if Resource._meta.get_field(self.order_by):
+                if Resource._meta.get_field(order_by_param):
                     qs = qs.order_by(self.order_by)
             except FieldDoesNotExist:
                 qs = self.get_unfiltered_queryset()


### PR DESCRIPTION
Closes #449 

Implemented the functionality to order resources by `name`, `availability` or `visibility`.

Clicking one of the mentioned buttons will redirect to the same page, setting GET parameters (t.ex. `?order_by=name`), and clicking it again will cause the parameter value to be prefixed with `-`.

The GET parameter value is used directly in the `order_by()` method of the queryset, and exceptions will return an unfiltered queryset.