### PR TITLE
Days in opening periods sorted properly in Respa Admin

### DIFF
--- a/respa_admin/static_src/js/resourceForm.js
+++ b/respa_admin/static_src/js/resourceForm.js
@@ -164,7 +164,7 @@ function enablePeriodEventHandlers() {
   }
 }
 
-function initialSortPeriodDays() {
+export function initialSortPeriodDays() {
   let periods = getPeriodsList();
 
   for (let i = 0; i < periods.length; i++) {

--- a/respa_admin/static_src/js/resourceForm.js
+++ b/respa_admin/static_src/js/resourceForm.js
@@ -11,6 +11,7 @@ import {
   removePeriod,
   modifyDays,
   copyTimePeriod,
+  sortPeriodDays,
 } from './resourceFormPeriods';
 
 import {
@@ -64,6 +65,7 @@ function setPeriodAndDayItems() {
   let $servedDayItem = $daysList[$daysList.length-1];
 
   emptyDayItem = $($servedDayItem).clone();
+  emptyDayItem.removeClass('original-day');  // added days are not original. used for sorting formset indices.
   emptyPeriodItem = $($servedPeriodItem).clone();
 
   $servedDayItem.remove();
@@ -159,6 +161,14 @@ function enablePeriodEventHandlers() {
 
     const removeButton = $('#remove-button-' + i);
     removeButton.click(() => removePeriod(periods[i]));
+  }
+}
+
+function initialSortPeriodDays() {
+  let periods = getPeriodsList();
+
+  for (let i = 0; i < periods.length; i++) {
+    sortPeriodDays($(periods[i]));
   }
 }
 

--- a/respa_admin/static_src/js/resourceFormIndex.js
+++ b/respa_admin/static_src/js/resourceFormIndex.js
@@ -1,4 +1,4 @@
-import { initializeEventHandlers, setClonableItems }  from './resourceForm';
+import { initializeEventHandlers, initialSortPeriodDays, setClonableItems }  from './resourceForm';
 import { toggleCurrentLanguage, calculateTranslatedFields }  from './resourceFormLanguage';
 
 function start() {
@@ -6,6 +6,7 @@ function start() {
   setClonableItems();
   toggleCurrentLanguage();
   calculateTranslatedFields();
+  initialSortPeriodDays();
 }
 
 window.addEventListener('load', start, false);

--- a/respa_admin/static_src/js/resourceFormPeriods.js
+++ b/respa_admin/static_src/js/resourceFormPeriods.js
@@ -110,13 +110,14 @@ function updatePeriodDaysIndices($periodItem) {
     })
   };
 
-  let index = 0;
-  for (;index < originalDaysList.length; index++) {
-    setIndex(index, originalDaysList[index]);
+  let dayIndex = 0;
+  for (let i = 0;i < originalDaysList.length; i++) {
+    setIndex(dayIndex, originalDaysList[i]);
+    dayIndex++;
   }
-  for (let newDayLoopIndex = 0;newDayLoopIndex < newDaysList.length; newDayLoopIndex++) {
-    setIndex(index, newDaysList[newDayLoopIndex]);
-    index++;
+  for (let i = 0;i < newDaysList.length; i++) {
+    setIndex(dayIndex, newDaysList[i]);
+    dayIndex++;
   }
 }
 
@@ -260,7 +261,7 @@ export function modifyDays($periodItem, $dates) {
   }
 
   //If a value does not exist in newDays but it does exist in currentDays => remove it.
-  for (let i = 0; i < currentDays.length; i++) {
+  for (let i = currentDays.length - 1; i >= 0 ; i--) {
     if (!newDays.includes(currentDays[i])) {
       removeDay($periodItem, i);
     }

--- a/respa_admin/static_src/styles/page-resource.scss
+++ b/respa_admin/static_src/styles/page-resource.scss
@@ -13,12 +13,12 @@
       flex-direction: column;
       justify-content: center;
     }
-    
+
     span.resources-count {
       font-size: 24px;
     }
   }
-    
+
   .resources-search {
     max-width: 700px;
 
@@ -32,7 +32,7 @@
       background-color: transparent;
       border: 0;
       padding-left: 0;
-      padding-right: 24px; 
+      padding-right: 24px;
       font-size: $font-size-h5;
     }
 
@@ -48,4 +48,9 @@
       border-right: 0;
     }
   }
+}
+
+.period-weekday select {
+  padding-right: 0;
+  pointer-events: none;
 }

--- a/respa_admin/templates/respa_admin/common/_period_day.html
+++ b/respa_admin/templates/respa_admin/common/_period_day.html
@@ -1,16 +1,15 @@
 {% load i18n %}
 
 {% with forloop.counter0 as dayId %}
-    <div class="weekday-row input-row" id="period-day-{{ id }}-{{ dayId }}">
+    <div class="weekday-row input-row original-day" id="period-day-{{ id }}-{{ dayId }}">
 
         <div id="day-db-ids">
             {{ day.period }}
             {{ day.id }}
         </div>
 
-        <span class="select-dropdown btn btn-primary">
+        <span class="select-dropdown btn btn-primary period-weekday">
             {{ day.weekday }}
-            <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
         </span>
 
         <div class="form-group">


### PR DESCRIPTION
Closes #451 

The days are always sorted starting from the weekday that is selected as the starting day.
Weekday names are no clickable, so the user can not select for example two Tuesdays, but has to obey the weekdays generated via selecting the start and end days.