### PR TITLE
Add functionality to display respa admin instructions

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -894,6 +894,9 @@ msgstr "Varattavissa"
 msgid "Please check the opening hours."
 msgstr "Tarkista aukioloajat."
 
+msgid "Instructions"
+msgstr "Ohjeet"
+
 msgid "Log out"
 msgstr "Kirjaudu ulos"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -895,6 +895,9 @@ msgstr "Kan reserveras"
 msgid "Please check the opening hours."
 msgstr "Kontrollera öppethållningstider"
 
+msgid "Instructions"
+msgstr "Instruktioner"
+
 msgid "Log out"
 msgstr "Logga ut"
 

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -160,7 +160,6 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'respa_admin.context_processors.export_global_vars',
             ],
         },
     },

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -37,6 +37,7 @@ env = environ.Env(
     ACCESSIBILITY_API_BASE_URL=(str, 'https://asiointi.hel.fi/kapaesteettomyys/'),
     ACCESSIBILITY_API_SYSTEM_ID=(str, ''),
     ACCESSIBILITY_API_SECRET=(str, ''),
+    RESPA_ADMIN_INSTRUCTIONS_URL=(str, ''),
 )
 environ.Env.read_env()
 
@@ -159,6 +160,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'respa_admin.context_processors.export_global_vars',
             ],
         },
     },
@@ -289,6 +291,8 @@ RESPA_ADMIN_ACCESSIBILITY_VISIBILITY = [
     'studio',  # Studio
     'workspace',  # Työtila
 ]
+
+RESPA_ADMIN_INSTRUCTIONS_URL = env('RESPA_ADMIN_INSTRUCTIONS_URL')
 
 if env('MAIL_MAILGUN_KEY'):
     ANYMAIL = {

--- a/respa_admin/context_processors.py
+++ b/respa_admin/context_processors.py
@@ -3,5 +3,5 @@ from django.conf import settings
 
 def export_global_vars(request):
     data = {}
-    data['INSTRUCTIONS_URL'] = settings.RESPA_ADMIN_INSTRUCTIONS_URL
+    data['RESPA_ADMIN_INSTRUCTIONS_URL'] = settings.RESPA_ADMIN_INSTRUCTIONS_URL
     return data

--- a/respa_admin/context_processors.py
+++ b/respa_admin/context_processors.py
@@ -1,7 +1,0 @@
-from django.conf import settings
-
-
-def export_global_vars(request):
-    data = {}
-    data['RESPA_ADMIN_INSTRUCTIONS_URL'] = settings.RESPA_ADMIN_INSTRUCTIONS_URL
-    return data

--- a/respa_admin/context_processors.py
+++ b/respa_admin/context_processors.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+
+
+def export_global_vars(request):
+    data = {}
+    data['INSTRUCTIONS_URL'] = settings.RESPA_ADMIN_INSTRUCTIONS_URL
+    return data

--- a/respa_admin/templates/respa_admin/_nav.html
+++ b/respa_admin/templates/respa_admin/_nav.html
@@ -33,9 +33,9 @@
                         {% endfor %}
                     </ul>
                 </li>
-                {% if INSTRUCTIONS_URL %}
+                {% if RESPA_ADMIN_INSTRUCTIONS_URL %}
                 <li>
-                    <a href="{{ INSTRUCTIONS_URL }}">
+                    <a href="{{ RESPA_ADMIN_INSTRUCTIONS_URL }}" target="_blank" rel="noopener noreferrer">
                         <span class="glyphicon glyphicon-question-sign icon-left" aria-hidden="true"></span>
                         {% trans "Instructions" %}
                     </a>

--- a/respa_admin/templates/respa_admin/_nav.html
+++ b/respa_admin/templates/respa_admin/_nav.html
@@ -33,6 +33,14 @@
                         {% endfor %}
                     </ul>
                 </li>
+                {% if INSTRUCTIONS_URL %}
+                <li>
+                    <a href="{{ INSTRUCTIONS_URL }}">
+                        <span class="glyphicon glyphicon-question-sign icon-left" aria-hidden="true"></span>
+                        {% trans "Instructions" %}
+                    </a>
+                </li>
+                {% endif %}
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-hidden="true">
                         <svg class="nav-icon" aria-hidden="true" viewBox="0 0 512 512">

--- a/respa_admin/templates/respa_admin/_nav.html
+++ b/respa_admin/templates/respa_admin/_nav.html
@@ -12,6 +12,14 @@
         <!-- Collect the nav links, forms, and other content for toggling -->
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav navbar-right">
+                {% if INSTRUCTIONS_URL %}
+                <li>
+                    <a href="{{ INSTRUCTIONS_URL }}" target="_blank" rel="noopener noreferrer">
+                        <span class="glyphicon glyphicon-question-sign icon-left" aria-hidden="true"></span>
+                        {% trans "Instructions" %}
+                    </a>
+                </li>
+                {% endif %}
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-hidden="true">
                         <svg class="nav-icon" aria-hidden="true" viewBox="0 0 512 512">
@@ -33,14 +41,6 @@
                         {% endfor %}
                     </ul>
                 </li>
-                {% if RESPA_ADMIN_INSTRUCTIONS_URL %}
-                <li>
-                    <a href="{{ RESPA_ADMIN_INSTRUCTIONS_URL }}" target="_blank" rel="noopener noreferrer">
-                        <span class="glyphicon glyphicon-question-sign icon-left" aria-hidden="true"></span>
-                        {% trans "Instructions" %}
-                    </a>
-                </li>
-                {% endif %}
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-hidden="true">
                         <svg class="nav-icon" aria-hidden="true" viewBox="0 0 512 512">

--- a/respa_admin/views/base.py
+++ b/respa_admin/views/base.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+
+class ExtraContextMixin():
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['INSTRUCTIONS_URL'] = settings.RESPA_ADMIN_INSTRUCTIONS_URL
+        return context

--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -6,6 +6,7 @@ from django.template.response import TemplateResponse
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, ListView
 from django.utils.translation import ugettext_lazy as _
+from respa_admin.views.base import ExtraContextMixin
 
 from resources.models import (
     Resource,
@@ -26,7 +27,7 @@ from respa_admin.forms import (
 from respa_admin import accessibility_api
 
 
-class ResourceListView(ListView):
+class ResourceListView(ExtraContextMixin, ListView):
     model = Resource
     paginate_by = 10
     context_object_name = 'resources'
@@ -89,7 +90,7 @@ def admin_office(request):
     return TemplateResponse(request, 'respa_admin/page_office.html')
 
 
-class SaveResourceView(CreateView):
+class SaveResourceView(ExtraContextMixin, CreateView):
     """
     View for saving new resources and updating existing resources.
     """


### PR DESCRIPTION
Closes #488 

Implemented functionality to display a button in the UI to redirect to respa admin instructions.
It reads `RESPA_ADMIN_INSTRUCTIONS_URL` variable from `.env` file, and `ExtraContextMixin` mixin sets it into context, which is inherited in needed views. 

`RESPA_ADMIN_INSTRUCTIONS_URL` defaults to an empty string, and in that case the new Instructions-button wont be displayed in UI, so it won't cause any problems in case the said variable is not set.