### PR TITLE
Feature/495 api order by

### DIFF
--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -330,16 +330,15 @@ class ResourceFilterSet(django_filters.FilterSet):
                                          widget=django_filters.widgets.CSVWidget, distinct=True)
     order_by = django_filters.OrderingFilter(
         fields=(
-            ('resource_name_fi', 'name__fi'),
-            ('resource_name_en', 'name__en'),
-            ('resource_name_sv', 'name__sv'),
-            ('unit_name_fi', 'name_fi'),
-            ('unit_name_en', 'name_en'),
-            ('unit_name_sv', 'name_sv'),
+            ('name_fi', 'resource_name_fi'),
+            ('name_en', 'resource_name_en'),
+            ('name_sv', 'resource_name_sv'),
+            ('unit__name_fi', 'unit_name_fi'),
+            ('unit__name_en', 'unit_name_en'),
+            ('unit__name_sv', 'unit_name_sv'),
             ('type', 'type'),
             ('unit', 'unit'),
             ('people_capacity', 'people_capacity'),
-            # ('open_now', 'open_now'),
         ),
     )
 

--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -97,6 +97,7 @@ class ResourceTypeViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
     filterset_class = ResourceTypeFilterSet
 
+
 register_view(ResourceTypeViewSet, 'type')
 
 
@@ -327,6 +328,20 @@ class ResourceFilterSet(django_filters.FilterSet):
                                                   widget=DRFFilterBooleanWidget)
     municipality = django_filters.Filter(field_name='unit__municipality_id', lookup_expr='in',
                                          widget=django_filters.widgets.CSVWidget, distinct=True)
+    order_by = django_filters.OrderingFilter(
+        fields=(
+            ('resource_name_fi', 'name__fi'),
+            ('resource_name_en', 'name__en'),
+            ('resource_name_sv', 'name__sv'),
+            ('unit_name_fi', 'name_fi'),
+            ('unit_name_en', 'name_en'),
+            ('unit_name_sv', 'name_sv'),
+            ('type', 'type'),
+            ('unit', 'unit'),
+            ('people_capacity', 'people_capacity'),
+            # ('open_now', 'open_now'),
+        ),
+    )
 
     def filter_is_favorite(self, queryset, name, value):
         if not self.user.is_authenticated:

--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -337,7 +337,6 @@ class ResourceFilterSet(django_filters.FilterSet):
             ('unit__name_en', 'unit_name_en'),
             ('unit__name_sv', 'unit_name_sv'),
             ('type', 'type'),
-            ('unit', 'unit'),
             ('people_capacity', 'people_capacity'),
         ),
     )

--- a/resources/tests/test_resource_api.py
+++ b/resources/tests/test_resource_api.py
@@ -709,3 +709,136 @@ def test_filtering_by_municipality(list_url, api_client, resource_in_unit, test_
     response = api_client.get('%s?municipality=bar' % list_url)
     assert response.status_code == 200
     assert_response_objects(response, []) 
+
+
+@pytest.mark.django_db
+def test_order_by_filter(list_url, api_client, resource_in_unit, resource_in_unit2):
+    # test resource_name_fi
+    resource_in_unit.name_fi, resource_in_unit.name_en, resource_in_unit.name_sv = 'aaa'
+    resource_in_unit.save()
+
+    resource_in_unit2.name_fi, resource_in_unit2.name_en, resource_in_unit2.name_sv = 'bbb'
+    resource_in_unit2.save()
+
+    response = api_client.get('%s?order_by=resource_name_fi' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][0]['name']['fi'] == resource_in_unit.name_fi
+    assert response.data['results'][1]['name']['fi'] == resource_in_unit2.name_fi
+
+    response = api_client.get('%s?order_by=-resource_name_fi' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][1]['name']['fi'] == resource_in_unit.name_fi
+    assert response.data['results'][0]['name']['fi'] == resource_in_unit2.name_fi
+
+    # test resource_name_en
+    response = api_client.get('%s?order_by=resource_name_en' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][0]['name']['en'] == resource_in_unit.name_en
+    assert response.data['results'][1]['name']['en'] == resource_in_unit2.name_en
+
+    response = api_client.get('%s?order_by=-resource_name_en' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][1]['name']['en'] == resource_in_unit.name_en
+    assert response.data['results'][0]['name']['en'] == resource_in_unit2.name_en
+
+    # test resource_name_sv
+    response = api_client.get('%s?order_by=resource_name_sv' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][0]['name']['sv'] == resource_in_unit.name_sv
+    assert response.data['results'][1]['name']['sv'] == resource_in_unit2.name_sv
+
+    response = api_client.get('%s?order_by=-resource_name_sv' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][1]['name']['sv'] == resource_in_unit.name_sv
+    assert response.data['results'][0]['name']['sv'] == resource_in_unit2.name_sv
+
+    # test unit_name_fi
+    resource_in_unit.unit.name_fi, resource_in_unit.unit.name_en, resource_in_unit.unit.name_sv = 'aaa'
+    resource_in_unit.unit.save()
+
+    resource_in_unit2.unit.name_fi, resource_in_unit2.unit.name_en, resource_in_unit2.unit.name_sv = 'bbb'
+    resource_in_unit2.unit.save()
+
+    response = api_client.get('%s?order_by=unit_name_fi' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][0]['unit'] == resource_in_unit.unit.id
+    assert response.data['results'][1]['unit'] == resource_in_unit2.unit.id
+
+    response = api_client.get('%s?order_by=-unit_name_fi' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][1]['unit'] == resource_in_unit.unit.id
+    assert response.data['results'][0]['unit'] == resource_in_unit2.unit.id
+
+    # test unit_name_en
+    response = api_client.get('%s?order_by=unit_name_en' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][0]['unit'] == resource_in_unit.unit.id
+    assert response.data['results'][1]['unit'] == resource_in_unit2.unit.id
+
+    response = api_client.get('%s?order_by=-unit_name_en' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][1]['unit'] == resource_in_unit.unit.id
+    assert response.data['results'][0]['unit'] == resource_in_unit2.unit.id
+
+    # test unit_name_sv
+    response = api_client.get('%s?order_by=unit_name_sv' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][0]['unit'] == resource_in_unit.unit.id
+    assert response.data['results'][1]['unit'] == resource_in_unit2.unit.id
+
+    response = api_client.get('%s?order_by=-unit_name_sv' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][1]['unit'] == resource_in_unit.unit.id
+    assert response.data['results'][0]['unit'] == resource_in_unit2.unit.id
+
+    # test resource type
+    resource_in_unit.type = ResourceType(id='aaaa', main_type='aaaa', name='aaaa')
+    resource_in_unit.type.save()
+    resource_in_unit.save()
+
+    resource_in_unit2.type = ResourceType(id='bbbb', main_type='bbbb', name='bbbb')
+    resource_in_unit2.type.save()
+    resource_in_unit2.save()
+
+    response = api_client.get('%s?order_by=type' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][0]['unit'] == resource_in_unit.unit.id
+    assert response.data['results'][1]['unit'] == resource_in_unit2.unit.id
+
+    response = api_client.get('%s?order_by=-type' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][1]['unit'] == resource_in_unit.unit.id
+    assert response.data['results'][0]['unit'] == resource_in_unit2.unit.id
+
+    # test resource people capacity
+    resource_in_unit.people_capacity = 1
+    resource_in_unit.save()
+
+    resource_in_unit2.people_capacity = 50
+    resource_in_unit2.save()
+
+    response = api_client.get('%s?order_by=people_capacity' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][0]['people_capacity'] == resource_in_unit.people_capacity
+    assert response.data['results'][1]['people_capacity'] == resource_in_unit2.people_capacity
+
+    response = api_client.get('%s?order_by=-people_capacity' % list_url)
+    assert response.status_code == 200
+    assert_response_objects(response, [resource_in_unit, resource_in_unit2])
+    assert response.data['results'][1]['people_capacity'] == resource_in_unit.people_capacity
+    assert response.data['results'][0]['people_capacity'] == resource_in_unit2.people_capacity

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -474,6 +474,11 @@ paths:
           description: Only return resources that belong to units that are located in the given municipality.
           required: false
           type: string
+        - name: order_by
+          in: query
+          description: Order queryset by given resource fields, accepted values are `resource_name_fi`, `resource_name_en`, `resource_name_sv`, `unit_name_fi`, `unit_name_en`, `unit_name_sv`, `type`, `people_capacity`. Prefix parameter value with `-` to get reverse ordering.
+          required: false
+          type: string
       responses:
         '200':
           description: Successful response


### PR DESCRIPTION
Closes #495 

Add new filter parameter `order_by` to ResourceFilterSet.

Quote from swagger documentation: 

> Order queryset by given resource fields, accepted values are `resource_name_fi`, `resource_name_en`, `resource_name_sv`, `unit_name_fi`, `unit_name_en`, `unit_name_sv`, `type`, `people_capacity`. Prefix parameter value with `-` to get reverse ordering.