### PR TITLE
Change ResourceViewSet to use visible_for method of resource model

### DIFF
--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -643,17 +643,13 @@ class ResourceViewSet(munigeo_api.GeoModelAPIView, mixins.RetrieveModelMixin,
         return context
 
     def get_queryset(self):
-        if is_general_admin(self.request.user):
-            return self.queryset
-        else:
-            return self.queryset.filter(public=True)
+        return self.queryset.visible_for(self.request.user)
 
     def _set_favorite(self, request, value):
         resource = self.get_object()
         user = request.user
 
         exists = user.favorite_resources.filter(id=resource.id).exists()
-
         if value:
             if not exists:
                 user.favorite_resources.add(resource)


### PR DESCRIPTION
Closes #509 

Changed `ResourceViewSet`'s `get_queryset` to use `visible_for` filtering method.

The problem was caused due to the fact that `ResourceViewSet` contained duplicate code which weren't inherited, and thus went out of date when changes were made to `visible_for` method of ResourceQuerySet.