### PR TITLE
Remove prefix from field

### DIFF
--- a/respa_admin/templates/respa_admin/resources/form/_booking.html
+++ b/respa_admin/templates/respa_admin/resources/form/_booking.html
@@ -18,7 +18,7 @@
         {% include "respa_admin/forms/_input.html" with field=form.reservable_min_days_in_advance %}
     </div>
     <div class="input-row">
-        {% include "respa_admin/forms/_input.html" with field=form.max_reservations_per_user prefix_text="pcs" %}
+        {% include "respa_admin/forms/_input.html" with field=form.max_reservations_per_user %}
     </div>
     <div class="form-group booking-info">
         <div class="textarea-wrapper">


### PR DESCRIPTION
Closes #508 

Remove `pcs` prefix from form field.