### PR TITLE
Add SessionAuthentication to ReservationViewSet and ResourceViewSet

### DIFF
--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -12,7 +12,7 @@ from django.db.models import Q
 from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets, serializers, filters, exceptions, permissions
-from rest_framework.authentication import TokenAuthentication
+from rest_framework.authentication import TokenAuthentication, SessionAuthentication
 from rest_framework.fields import BooleanField, IntegerField
 from rest_framework import renderers
 from rest_framework.exceptions import NotAcceptable, ValidationError
@@ -518,7 +518,7 @@ class ReservationViewSet(munigeo_api.GeoModelAPIView, viewsets.ModelViewSet, Res
     pagination_class = ReservationPagination
     authentication_classes = (
         list(drf_settings.DEFAULT_AUTHENTICATION_CLASSES) +
-        [TokenAuthentication])
+        [TokenAuthentication, SessionAuthentication])
     ordering_fields = ('begin',)
 
     def get_serializer(self, *args, **kwargs):

--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -13,6 +13,7 @@ from django.contrib.gis.db.models.functions import Distance
 from django.contrib.gis.geos import Point
 from resources.pagination import PurposePagination
 from rest_framework import exceptions, filters, mixins, serializers, viewsets, response, status
+from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
 from guardian.core import ObjectPermissionChecker
 
@@ -28,6 +29,7 @@ from .base import TranslatedModelSerializer, register_view, DRFFilterBooleanWidg
 from .reservation import ReservationSerializer
 from .unit import UnitSerializer
 from .equipment import EquipmentSerializer
+from rest_framework.settings import api_settings as drf_settings
 
 
 def parse_query_time_range(params):
@@ -616,6 +618,9 @@ class ResourceListViewSet(munigeo_api.GeoModelAPIView, mixins.ListModelMixin,
     search_fields = ('name_fi', 'description_fi', 'unit__name_fi',
                      'name_sv', 'description_sv', 'unit__name_sv',
                      'name_en', 'description_en', 'unit__name_en')
+    authentication_classes = (
+        list(drf_settings.DEFAULT_AUTHENTICATION_CLASSES) +
+        [SessionAuthentication])
 
     def get_serializer(self, page, *args, **kwargs):
         self._page = page


### PR DESCRIPTION
Closes #510 
Closes #479 

As discussed, instead of accepting the API key to be used through GET-parameter, we decided to go with session authentication instead.

Added session authentication to `resource` and `reservation` endpoints.