### PR TITLE
Update dev/Dockerfile to match the one used in prod

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.5
+FROM python:3.6
 
 WORKDIR /usr/src/app
 
 ENV APP_NAME respa
 
-RUN apt-get update && apt-get install -y libgdal1h postgresql-client-9.4
+RUN apt-get update && apt-get install -y gdal-bin postgresql-client
 
 COPY requirements.txt ./requirements.txt
 COPY dev-requirements.txt ./dev-requirements.txt


### PR DESCRIPTION
The Dockerfile used in production uses already Python 3.6 and
has hence slightly differently named packages for libgdal and postgres
client.

These changes makes the Docker dev setup to be up to date with prod.