### PR TITLE
Change user to be raw id field in ReservationAdmin

### DIFF
--- a/resources/admin/__init__.py
+++ b/resources/admin/__init__.py
@@ -164,6 +164,7 @@ class ReservationAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, Extr
                        admin.ModelAdmin):
     extra_readonly_fields_on_update = ('access_code',)
     search_fields = ('user__first_name', 'user__last_name', 'user__username', 'user__email')
+    raw_id_fields = ('user',)
 
 
 class ResourceTypeAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, TranslationAdmin):


### PR DESCRIPTION
Closes #503 

Changed user to be raw id field in ReservationAdmin. `Unit authorization` and `Unit group authorization` models don't display a full list of all the users, therefore I didn't touch those. 