### PR TITLE
Change Order price API endpoint to work without a Reservation

### DIFF
--- a/payments/integrations/bambora_payform.py
+++ b/payments/integrations/bambora_payform.py
@@ -14,6 +14,7 @@ from .payments_base import (
 )
 from .. import settings
 from ..models import Order
+from ..utils import price_as_sub_units
 
 UI_RETURN_URL_PARAM_NAME = 'RESPA_UI_RETURN_URL'
 
@@ -130,8 +131,8 @@ class BamboraPayformPayments(PaymentsBase):
             yield PurchasedItem(
                 id=product.code,
                 title=product.name,
-                price=product.get_price_for_reservation(reservation, as_sub_units=True),
-                pretax_price=product.get_pretax_price_for_reservation(reservation, as_sub_units=True),
+                price=price_as_sub_units(product.get_price_for_reservation(reservation)),
+                pretax_price=price_as_sub_units(product.get_pretax_price_for_reservation(reservation)),
                 tax=product.tax_percentage,
                 count=1,
                 type=1

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -1,0 +1,9 @@
+from decimal import Decimal, ROUND_HALF_UP
+
+
+def price_as_sub_units(price: Decimal) -> int:
+    return int(round_price(price) * 100)
+
+
+def round_price(price: Decimal) -> Decimal:
+    return price.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)


### PR DESCRIPTION
Instead of a reservation ID, the endpoint now requires a time range for the
price calculations, which is given by "begin" and "end" datetimes.

The change required some price helper refactoring, which hopefully also made
those somewhat cleaner and more usable.

Refs RESPA-66