### PR TITLE
Tweak active payment provider selection, configuration and usage

### DIFF
--- a/payments/integrations/__init__.py
+++ b/payments/integrations/__init__.py
@@ -1,12 +1,33 @@
-from .bambora_payform import BamboraPayformPayments
+import environ
 
+from django.conf import settings
+from django.utils.module_loading import import_string
 
 _payment_provider = None
 
 
 def get_payment_provider():
+    """Load and cache the active payment provider"""
     global _payment_provider
     if not _payment_provider:
-        # TODO where/how should we choose this?
-        _payment_provider = BamboraPayformPayments()
+
+        # Provider path is the only thing loaded from env
+        # in the global settings, the rest are added here
+        provider_path = getattr(settings, 'RESPA_PAYMENTS_PROVIDER')
+        provider = import_string(provider_path)
+
+        # Provider tells what keys and types it requires for configuration
+        # and the corresponding data has to be set in .env
+        template = provider.get_config_template()
+        env = environ.Env(**template)
+
+        config = {}
+        for key in template.keys():
+            if hasattr(settings, key):
+                config[key] = getattr(settings, key)
+            else:
+                config[key] = env(key)
+
+        _payment_provider = provider(PAYMENT_CONFIG=config)
+
     return _payment_provider

--- a/payments/integrations/payments_base.py
+++ b/payments/integrations/payments_base.py
@@ -1,41 +1,15 @@
-from collections import namedtuple
-
 from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
 from django.shortcuts import redirect
 from django.urls import reverse
 
-from payments import settings
-
-PurchasedItem = namedtuple('PurchasedItem',
-                           'id, title, price, pretax_price, tax count type')
-
-Customer = namedtuple('Customer',
-                      'firstname lastname email address_street address_zip address_city')
+PAYMENT_CONFIG = 'PAYMENT_CONFIG'
 
 
 class PaymentsBase(object):
     """Common base for payment provider integrations"""
 
     def __init__(self, **kwargs):
-        self.api_key = settings.PAYMENT_API_KEY
-        self.api_secret = settings.PAYMENT_API_SECRET
-        self.url_api = settings.PAYMENT_URL_API
-
-    def order_post(self):
-        raise NotImplementedError
-
-    def get_customer(self):
-        raise NotImplementedError
-
-    def get_purchased_items(self):
-        return []
-
-    def calculate_auth_code(self, data):
-        """Calculate and return a hash of some data
-
-        As the hashing algorithms and data varies between providers
-        there needs to be a subclass implementation"""
-        raise NotImplementedError
+        self.config = kwargs.get(PAYMENT_CONFIG)
 
     def handle_success_request(self, request: HttpRequest) -> HttpResponse:
         """Handle incoming payment success request from the payment provider.

--- a/payments/settings.py
+++ b/payments/settings.py
@@ -1,8 +1,0 @@
-from django.conf import settings
-
-PAYMENT_API_KEY = getattr(settings, 'PAYMENT_API_KEY', '')
-PAYMENT_API_SECRET = getattr(settings, 'PAYMENT_API_SECRET', '')
-
-PAYMENT_URL_API = 'https://payform.bambora.com/pbwapi'
-PAYMENT_URL_API_AUTH = '{}/auth_payment'.format(PAYMENT_URL_API)
-PAYMENT_URL_API_TOKEN = '{}/token/{{token}}'.format(PAYMENT_URL_API)

--- a/payments/tests/test_bambora_payform.py
+++ b/payments/tests/test_bambora_payform.py
@@ -1,0 +1,73 @@
+import json
+import pytest
+
+from payments.integrations.bambora_payform import (
+    BamboraPayformPayments,
+    PayloadValidationError,
+    DuplicateOrderError,
+    ServiceUnavailableError,
+    UnknownReturnCodeError
+)
+
+
+@pytest.fixture()
+def payment_provider():
+    config = {
+        'PAYMENT_BAMBORA_API_KEY': 'dummy-key',
+        'PAYMENT_BAMBORA_API_SECRET': 'dummy-secret',
+        'PAYMENT_BAMBORA_METHODS_ENABLED': ['dummy-bank']
+    }
+    return BamboraPayformPayments(PAYMENT_CONFIG=config)
+
+
+def test_handle_order_create_success(payment_provider):
+    """Test the response handler recognizes success and adds token as part of the returned url"""
+    r = json.loads("""{
+        "result": 0,
+        "token": "abc123",
+        "type": "e-payment"
+    }""")
+    return_value = payment_provider.handle_order_create(r)
+    assert r['token'] in return_value
+
+
+def test_handle_order_create_error_validation(payment_provider):
+    """Test the response handler raises PayloadValidationError as expected"""
+    r = json.loads("""{
+        "result": 1,
+        "type": "e-payment",
+        "errors": ["Invalid auth code"]
+    }""")
+    with pytest.raises(PayloadValidationError):
+        payment_provider.handle_order_create(r)
+
+
+def test_handle_order_create_error_duplicate(payment_provider):
+    """Test the response handler raises DuplicateOrderError as expected"""
+    r = json.loads("""{
+        "result": 2,
+        "type": "e-payment"
+    }""")
+    with pytest.raises(DuplicateOrderError):
+        payment_provider.handle_order_create(r)
+
+
+def test_handle_order_create_error_unavailable(payment_provider):
+    """Test the response handler raises ServiceUnavailableError as expected"""
+    r = json.loads("""{
+        "result": 10,
+        "type": "e-payment"
+    }""")
+    with pytest.raises(ServiceUnavailableError):
+        payment_provider.handle_order_create(r)
+
+
+def test_handle_order_create_error_unknown_code(payment_provider):
+    """Test the response handler raises UnknownReturnCodeError as expected"""
+    r = json.loads("""{
+        "result": 15,
+        "type": "e-payment",
+        "test": "unrecognized extra stuff"
+    }""")
+    with pytest.raises(UnknownReturnCodeError):
+        payment_provider.handle_order_create(r)

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -34,8 +34,7 @@ env = environ.Env(
     MAIL_MAILGUN_DOMAIN=(str, ''),
     MAIL_MAILGUN_API=(str, ''),
     RESPA_IMAGE_BASE_URL=(str, ''),
-    PAYMENT_API_KEY=(str, ''),
-    PAYMENT_API_SECRET=(str, ''),
+    RESPA_PAYMENTS_PROVIDER=(str, '')
 )
 environ.Env.read_env()
 
@@ -43,8 +42,8 @@ environ.Env.read_env()
 # reservation confirmation emails use this
 RESPA_IMAGE_BASE_URL = env('RESPA_IMAGE_BASE_URL')
 
-PAYMENT_API_KEY = env('PAYMENT_API_KEY')
-PAYMENT_API_SECRET = env('PAYMENT_API_SECRET')
+# Dotted path to the active payment provider class, see payments.integrations init
+RESPA_PAYMENTS_PROVIDER = env('RESPA_PAYMENTS_PROVIDER')
 
 BASE_DIR = root()
 


### PR DESCRIPTION
Move configuration away from global respa settings to the payment provider implementation and init.
Remove passing customer and product data through generic helpers at least for now.
Split the payment initialization so that the order create response handling can be tested without actually making network requests.
Add tests for different order create responses.

Refs RESPA-70