### PR TITLE
Allow enabling payments using a switch in settings

### DIFF
--- a/payments/admin.py
+++ b/payments/admin.py
@@ -1,11 +1,11 @@
+from django.conf import settings
 from django.contrib import admin
 from modeltranslation.admin import TranslationAdmin
 
 from payments.models import Order, OrderLine, Product
 
 
-@admin.register(Product)
-class Product(TranslationAdmin):
+class ProductAdmin(TranslationAdmin):
     list_display = ('product_id', 'name', 'type', 'pretax_price', 'price_type')
     readonly_fields = ('product_id',)
 
@@ -25,7 +25,11 @@ class OrderLineInline(admin.StackedInline):
     extra = 0
 
 
-@admin.register(Order)
 class OrderAdmin(admin.ModelAdmin):
     raw_id_fields = ('reservation',)
     inlines = (OrderLineInline,)
+
+
+if settings.RESPA_PAYMENTS_ENABLED:
+    admin.site.register(Product, ProductAdmin)
+    admin.site.register(Order, OrderAdmin)

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -34,6 +34,7 @@ env = environ.Env(
     MAIL_MAILGUN_DOMAIN=(str, ''),
     MAIL_MAILGUN_API=(str, ''),
     RESPA_IMAGE_BASE_URL=(str, ''),
+    RESPA_PAYMENTS_ENABLED=(bool, False),
     RESPA_PAYMENTS_PROVIDER_CLASS=(str, '')
 )
 environ.Env.read_env()
@@ -41,6 +42,8 @@ environ.Env.read_env()
 # used for generating links to images, when no request context is available
 # reservation confirmation emails use this
 RESPA_IMAGE_BASE_URL = env('RESPA_IMAGE_BASE_URL')
+
+RESPA_PAYMENTS_ENABLED = env('RESPA_PAYMENTS_ENABLED')
 
 # Dotted path to the active payment provider class, see payments.providers init.
 # Example value: 'payments.providers.BamboraPayformProvider'
@@ -294,8 +297,7 @@ if os.path.exists(local_settings_path):
         code = compile(fp.read(), local_settings_path, 'exec')
     exec(code, globals(), locals())
 
-
-if 'payments' in INSTALLED_APPS:
+if RESPA_PAYMENTS_ENABLED:
     RESPA_RESOURCE_SERIALIZER_CLASS = 'payments.api.ResourceSerializer'
     RESPA_RESOURCE_DETAILS_SERIALIZER_CLASS = 'payments.api.ResourceDetailsSerializer'
 

--- a/respa/urls.py
+++ b/respa/urls.py
@@ -17,7 +17,7 @@ if getattr(settings, 'RESPA_COMMENTS_ENABLED', False):
 if getattr(settings, 'RESPA_CATERINGS_ENABLED', False):
     import caterings.api
 
-if 'payments' in settings.INSTALLED_APPS:
+if settings.RESPA_PAYMENTS_ENABLED:
     import payments.api  # noqa
 
 router = RespaAPIRouter()
@@ -41,7 +41,7 @@ if 'reports' in settings.INSTALLED_APPS:
         path('reports/reservation_details/', ReservationDetailsReport.as_view(), name='reservation-details-report'),
     ])
 
-if 'payments' in settings.INSTALLED_APPS:
+if settings.RESPA_PAYMENTS_ENABLED:
     from payments import urls as payment_urls  # noqa
     urlpatterns.extend([
         path('payments/', include(payment_urls))


### PR DESCRIPTION
Payments are now disabled by default, and can be enabled by setting
RESPA_PAYMENTS_ENABLED to True in the env or in local_settings.py.