### PR TITLE
RESPA-91: Add unit.id as locationId to accessibility data input link.

### DIFF
--- a/respa_admin/accessibility_api.py
+++ b/respa_admin/accessibility_api.py
@@ -6,22 +6,27 @@ from hashlib import sha256
 from urllib.parse import quote
 
 
-def generate_url(api_url, system_id, target_id, target_name, user, secret, form_id="2", lang="fi"):
+def generate_url(api_url, system_id, target_id, target_name, user, secret, form_id='2', lang='fi', location_id=None):
     url = '{api_url}app/{lang}/target/'.format(api_url=api_url, lang=lang)
     valid_until = datetime.datetime.now() + datetime.timedelta(days=2)
     valid_until_iso8601 = valid_until.isoformat(timespec='seconds')
     url_params = {
-        "systemId": system_id,
-        "targetId": target_id,
-        "user": user,
-        "validUntil": valid_until_iso8601,
-        "name": target_name,
-        "formId": form_id,
+        'systemId': system_id,
+        'targetId': target_id,
+        'user': user,
+        'validUntil': valid_until_iso8601,
+        'name': target_name,
+        'formId': form_id,
     }
-    url_params.update({"checksum": calculate_checksum(url_params, secret)})
-    return "{}?{}".format(url, "&".join(["{}={}".format(key, quote(val)) for key, val in url_params.items()]))
+    if location_id is not None:
+        url_params['locationId'] = location_id
+    url_params['checksum'] = calculate_checksum(url_params, secret)
+    return '{}?{}'.format(url, '&'.join(['{}={}'.format(key, quote(val)) for key, val in url_params.items()]))
 
 
 def calculate_checksum(params, secret):
-    payload = str(secret) + "{systemId}{targetId}{user}{validUntil}{name}{formId}".format(**params)
+    checksum_params = params.copy()
+    if 'locationId' not in checksum_params:
+        checksum_params['locationId'] = ''
+    payload = str(secret) + '{systemId}{targetId}{locationId}{user}{validUntil}{name}{formId}'.format(**checksum_params)
     return sha256(payload.encode('utf8')).hexdigest().upper()

--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -165,6 +165,7 @@ class SaveResourceView(ExtraContextMixin, CreateView):
         secret = getattr(settings, 'RESPA_ADMIN_ACCESSIBILITY_API_SECRET', '')
         target_id = self.object.pk
         target_name = self.object.name
+        location_id = self.object.unit.id
         user = request.user.email or request.user.username
         return accessibility_api.generate_url(
             api_url,
@@ -173,6 +174,7 @@ class SaveResourceView(ExtraContextMixin, CreateView):
             target_name,
             user,
             secret,
+            location_id=location_id
         )
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
Accessibility API input can now accept building id and it allows copying accessibility data between meeting rooms in the same location.

Unit.id is used as the locationId.

Discussion point:
Should we something other than Unit.id? If other apps than Respa use the Accessibility API it would be useful if the locationIds would match. Units can have many UnitIdentifiers which can contain IDs in other systems such as TPREK or HELMET. How would we then choose which identifier to send to Accessibility API?