### PR TITLE
RESPA-94: Use UTC timestamps for reservation begin and end in ICAL files.

### DIFF
--- a/resources/models/utils.py
+++ b/resources/models/utils.py
@@ -225,9 +225,11 @@ def build_reservations_ical_file(reservations):
     cal['name'] = vText('RESPA')
     for reservation in reservations:
         event = Event()
+        begin_utc = timezone.localtime(reservation.begin, timezone.utc)
+        end_utc = timezone.localtime(reservation.end, timezone.utc)
         event['uid'] = 'respa_reservation_{}'.format(reservation.id)
-        event['dtstart'] = vDatetime(reservation.begin)
-        event['dtend'] = vDatetime(reservation.end)
+        event['dtstart'] = vDatetime(begin_utc)
+        event['dtend'] = vDatetime(end_utc)
         unit = reservation.resource.unit
         event['location'] = vText('{} {} {}'.format(unit.name, unit.street_address, unit.address_zip))
         if unit.location:


### PR DESCRIPTION
Some calendar clients seem to have problems with `Europe/Helsinki` timezone for some reason. Use UTC timestamps in an attempt to circumvent those problems.