### PR TITLE
Document multiple resource filtering

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -616,7 +616,7 @@ paths:
           type: integer
       - name: resource
         in: query
-        description: Resource id, for filtering reservations by resource
+        description: Resource id, for filtering reservations by resource. Accepts multiple comma-separated values.
         schema:
           type: string
       - name: all


### PR DESCRIPTION
Update documentation to include a change to the reservation endpoint. The resource filter now accepts multiple comma-separated values.