### PR TITLE
Add test coverage for payment provider and order price calc helpers

### DIFF
--- a/payments/tests/conftest.py
+++ b/payments/tests/conftest.py
@@ -1,1 +1,55 @@
+import datetime
+from decimal import Decimal
+
+import pytest
+from pytz import UTC
+
+from payments.factories import OrderFactory, OrderLineFactory
+from payments.models import Order
+from resources.models import Reservation
 from resources.tests.conftest import *  # noqa
+
+
+@pytest.fixture()
+def two_hour_reservation(resource_in_unit, user):
+    """A two-hour reservation fixture with actual datetime objects"""
+    return Reservation.objects.create(
+        resource=resource_in_unit,
+        begin=datetime.datetime(2119, 5, 5, 10, 0, 0, tzinfo=UTC),
+        end=datetime.datetime(2119, 5, 5, 12, 0, 0, tzinfo=UTC),
+        user=user,
+        event_subject='some fancy event',
+        host_name='esko',
+        reserver_name='martta',
+        state=Reservation.CONFIRMED
+    )
+
+
+@pytest.fixture()
+def order_with_products(two_hour_reservation):
+    order = OrderFactory.create(
+        order_number='abc123',
+        status=Order.WAITING,
+        payer_first_name='Seppo',
+        payer_last_name='Testi',
+        payer_email_address='test@example.com',
+        payer_address_street='Test street 1',
+        payer_address_zip='12345',
+        payer_address_city='Testcity',
+        reservation=two_hour_reservation
+    )
+    OrderLineFactory.create(
+        quantity=1,
+        product__name="Test product",
+        product__pretax_price=Decimal('10.00'),
+        product__tax_percentage=Decimal('24.00'),
+        order=order
+    )
+    OrderLineFactory.create(
+        quantity=1,
+        product__name="Test product 2",
+        product__pretax_price=Decimal('10.00'),
+        product__tax_percentage=Decimal('24.00'),
+        order=order
+    )
+    return order

--- a/payments/tests/test_bambora_payform.py
+++ b/payments/tests/test_bambora_payform.py
@@ -1,19 +1,28 @@
+import hmac
 import json
 
 import pytest
+from django.http import HttpResponse, HttpResponseBadRequest
+from django.test.client import RequestFactory
 
+from payments.models import Order
 from payments.providers.bambora_payform import (
-    BamboraPayformProvider, DuplicateOrderError, PayloadValidationError, ServiceUnavailableError,
-    UnknownReturnCodeError
+    RESPA_PAYMENTS_BAMBORA_API_KEY, BamboraPayformProvider, DuplicateOrderError, PayloadValidationError,
+    ServiceUnavailableError, UnknownReturnCodeError
 )
+
+
+@pytest.fixture(autouse=True)
+def auto_use_django_db(db):
+    pass
 
 
 @pytest.fixture()
 def payment_provider():
     config = {
-        'PAYMENT_BAMBORA_API_KEY': 'dummy-key',
-        'PAYMENT_BAMBORA_API_SECRET': 'dummy-secret',
-        'PAYMENT_BAMBORA_METHODS_ENABLED': ['dummy-bank']
+        'RESPA_PAYMENTS_BAMBORA_API_KEY': 'dummy-key',
+        'RESPA_PAYMENTS_BAMBORA_API_SECRET': 'dummy-secret',
+        'RESPA_PAYMENTS_BAMBORA_PAYMENT_METHODS': ['dummy-bank']
     }
     return BamboraPayformProvider(PAYMENT_CONFIG=config)
 
@@ -69,3 +78,276 @@ def test_handle_order_create_error_unknown_code(payment_provider):
     }""")
     with pytest.raises(UnknownReturnCodeError):
         payment_provider.handle_order_create(r)
+
+
+def test_payload_add_products_success(payment_provider, order_with_products):
+    """Test the products and total order price data is added correctly into payload"""
+    payload = {}
+    payment_provider.payload_add_products(payload, order_with_products)
+    assert 'amount' in payload
+    assert payload.get('amount') == 4960
+
+    assert 'products' in payload
+    products = payload.get('products')
+    assert len(products) == 2
+    # As there's no guaranteed order in nested dict, it's not possible
+    # to check reliably for values, but at least assert that all keys are added
+    for product in products:
+        assert 'id' in product
+        assert 'title' in product
+        assert 'price' in product
+        assert 'pretax_price' in product
+        assert 'tax' in product
+        assert 'count' in product
+        assert 'type' in product
+
+
+def test_payload_add_customer_success(payment_provider, order_with_products):
+    """Test the customer data from order is added correctly into payload"""
+    payload = {}
+    payment_provider.payload_add_customer(payload, order_with_products)
+
+    assert 'email' in payload
+    assert payload.get('email') == 'test@example.com'
+
+    assert 'customer' in payload
+    customer = payload.get('customer')
+    assert customer.get('firstname') == 'Seppo'
+    assert customer.get('lastname') == 'Testi'
+    assert customer.get('email') == 'test@example.com'
+    assert customer.get('address_street') == 'Test street 1'
+    assert customer.get('address_zip') == '12345'
+    assert customer.get('address_city') == 'Testcity'
+
+
+def test_payload_add_auth_code_success(payment_provider, order_with_products):
+    """Test the auth code is added correctly into the payload"""
+    payload = {
+        'api_key': payment_provider.config.get(RESPA_PAYMENTS_BAMBORA_API_KEY),
+        'order_number': order_with_products.order_number
+    }
+    payment_provider.payload_add_auth_code(payload)
+    assert 'authcode' in payload
+
+
+def test_calculate_auth_code_success(payment_provider):
+    """Test the auth code calculation returns a correct hash"""
+    data = 'dummy-key|abc123'
+    calculated_code = payment_provider.calculate_auth_code(data)
+    assert hmac.compare_digest(calculated_code, 'A8894068C4E17BFD55E68B2148CF555800773C673D19FA0648101C1E9CF5D0CE')
+
+
+def test_check_new_payment_authcode_success(payment_provider):
+    """Test the helper is able to extract necessary values from a request and compare authcodes"""
+    params = {
+        'RESPA_UI_RETURN_URL': 'http%3A%2F%2F127.0.0.1%3A8000%2Fv1',
+        'AUTHCODE': '905EDAC01C9E6921250C21BE23CDC53633A4D66BE7241A3B5DA1D2372234D462',
+        'RETURN_CODE': '0',
+        'ORDER_NUMBER': 'abc123',
+        'SETTLED': '1'
+    }
+    rf = RequestFactory()
+    request = rf.get('/payments/success/', params)
+    assert payment_provider.check_new_payment_authcode(request)
+
+
+def test_check_new_payment_authcode_invalid(payment_provider):
+    """Test the helper fails when params do not match the auth code"""
+    params = {
+        'RESPA_UI_RETURN_URL': 'http%3A%2F%2F127.0.0.1%3A8000%2Fv1',
+        'AUTHCODE': '905EDAC01C9E6921250C21BE23CDC53633A4D66BE7241A3B5DA1D2372234D462',
+        'RETURN_CODE': '0',
+        'ORDER_NUMBER': 'abc123',
+        'SETTLED': '0'
+    }
+    rf = RequestFactory()
+    request = rf.get('/payments/success/', params)
+    assert not payment_provider.check_new_payment_authcode(request)
+
+
+def test_handle_success_request_return_url_missing(payment_provider, order_with_products):
+    """Test the handler returns a bad request object if return URL is missing from params"""
+    params = {
+        'AUTHCODE': '905EDAC01C9E6921250C21BE23CDC53633A4D66BE7241A3B5DA1D2372234D462',
+        'RETURN_CODE': '0',
+        'ORDER_NUMBER': 'abc123',
+        'SETTLED': '0'
+    }
+    rf = RequestFactory()
+    request = rf.get('/payments/success/', params)
+    returned = payment_provider.handle_success_request(request)
+    assert isinstance(returned, HttpResponseBadRequest)
+    assert returned.status_code == 400
+
+
+def test_handle_success_request_order_not_found(payment_provider, order_with_products):
+    """Test request helper returns a failure url when order can't be found"""
+    params = {
+        'RESPA_UI_RETURN_URL': 'http%3A%2F%2F127.0.0.1%3A8000%2Fv1',
+        'AUTHCODE': '83F6C12E8D894B433CB2B6A2A56709CF0AE26665768ED74FB28922F6ED128301',
+        'RETURN_CODE': '0',
+        'ORDER_NUMBER': 'abc567',
+        'SETTLED': '1'
+    }
+    rf = RequestFactory()
+    request = rf.get('/payments/success/', params)
+    returned = payment_provider.handle_success_request(request)
+    assert isinstance(returned, HttpResponse)
+    assert 'payment_status=failure' in returned.url
+
+
+def test_handle_success_request_success(payment_provider, order_with_products):
+    """Test request helper changes the order status to confirmed
+
+    Also check it returns a success url with order number"""
+    params = {
+        'RESPA_UI_RETURN_URL': 'http%3A%2F%2F127.0.0.1%3A8000%2Fv1',
+        'AUTHCODE': '905EDAC01C9E6921250C21BE23CDC53633A4D66BE7241A3B5DA1D2372234D462',
+        'RETURN_CODE': '0',
+        'ORDER_NUMBER': 'abc123',
+        'SETTLED': '1'
+    }
+    rf = RequestFactory()
+    request = rf.get('/payments/success/', params)
+    returned = payment_provider.handle_success_request(request)
+    order_after = Order.objects.get(order_number=params.get('ORDER_NUMBER'))
+    assert order_after.status == Order.CONFIRMED
+    assert isinstance(returned, HttpResponse)
+    assert 'payment_status=success' in returned.url
+    assert 'order_id={}'.format(order_after.id) in returned.url
+
+
+def test_handle_success_request_payment_failed(payment_provider, order_with_products):
+    """Test request helper changes the order status to rejected and returns a failure url"""
+    params = {
+        'RESPA_UI_RETURN_URL': 'http%3A%2F%2F127.0.0.1%3A8000%2Fv1',
+        'AUTHCODE': 'ED754E8F2E7FE0CC269B9F6A1C197F19B8393F37A1B63BE1E889D53F87A5FCA1',
+        'RETURN_CODE': '1',
+        'ORDER_NUMBER': 'abc123',
+        'SETTLED': '1'
+    }
+    rf = RequestFactory()
+    request = rf.get('/payments/success/', params)
+    returned = payment_provider.handle_success_request(request)
+    order_after = Order.objects.get(order_number=params.get('ORDER_NUMBER'))
+    assert order_after.status == Order.REJECTED
+    assert isinstance(returned, HttpResponse)
+    assert 'payment_status=failure' in returned.url
+
+
+def test_handle_success_request_status_not_updated(payment_provider, order_with_products):
+    """Test request helper reacts to transaction status update error by returning a failure url"""
+    params = {
+        'RESPA_UI_RETURN_URL': 'http%3A%2F%2F127.0.0.1%3A8000%2Fv1',
+        'AUTHCODE': 'D9170B2C0C0F36E467517E0DF2FC7D89BBC7237597B6BE3B0DE11518F93D7342',
+        'RETURN_CODE': '4',
+        'ORDER_NUMBER': 'abc123',
+        'SETTLED': '1'
+    }
+    rf = RequestFactory()
+    request = rf.get('/payments/success/', params)
+    returned = payment_provider.handle_success_request(request)
+    # TODO Handling isn't final yet so there might be something extra that needs to be tested here
+    assert isinstance(returned, HttpResponse)
+    assert 'payment_status=failure' in returned.url
+
+
+def test_handle_success_request_maintenance_break(payment_provider, order_with_products):
+    """Test request helper reacts to maintenance break error by returning a failure url"""
+    params = {
+        'RESPA_UI_RETURN_URL': 'http%3A%2F%2F127.0.0.1%3A8000%2Fv1',
+        'AUTHCODE': '144662CEBD9861D4526C4147D10FB6C50FE1E02453701F8972B699CFD1F4A99E',
+        'RETURN_CODE': '10',
+        'ORDER_NUMBER': 'abc123',
+        'SETTLED': '1'
+    }
+    rf = RequestFactory()
+    request = rf.get('/payments/success/', params)
+    returned = payment_provider.handle_success_request(request)
+    # TODO Handling isn't final yet so there might be something extra that needs to be tested here
+    assert isinstance(returned, HttpResponse)
+    assert 'payment_status=failure' in returned.url
+
+
+def test_handle_success_request_unknown_error(payment_provider, order_with_products):
+    """Test request helper returns a failure url when status code is unknown"""
+    params = {
+        'RESPA_UI_RETURN_URL': 'http%3A%2F%2F127.0.0.1%3A8000%2Fv1',
+        'AUTHCODE': '3CD17A51E89C0A6DDDCA743AFCBD5DC40E8FF8AB97756089E75EC953A19A938C',
+        'RETURN_CODE': '15',
+        'ORDER_NUMBER': 'abc123',
+        'SETTLED': '1'
+    }
+    rf = RequestFactory()
+    request = rf.get('/payments/success/', params)
+    returned = payment_provider.handle_success_request(request)
+    assert isinstance(returned, HttpResponse)
+    assert 'payment_status=failure' in returned.url
+
+
+def test_handle_notify_request_order_not_found(payment_provider, order_with_products):
+    """Test request notify helper returns http 204 when order can't be found"""
+    params = {
+        'RESPA_UI_RETURN_URL': 'http%3A%2F%2F127.0.0.1%3A8000%2Fv1',
+        'AUTHCODE': '83F6C12E8D894B433CB2B6A2A56709CF0AE26665768ED74FB28922F6ED128301',
+        'RETURN_CODE': '0',
+        'ORDER_NUMBER': 'abc567',
+        'SETTLED': '1'
+    }
+    rf = RequestFactory()
+    request = rf.get('/payments/notify/', params)
+    returned = payment_provider.handle_notify_request(request)
+    assert isinstance(returned, HttpResponse)
+    assert returned.status_code == 204
+
+
+def test_handle_notify_request_success(payment_provider, order_with_products):
+    """Test request notify helper returns http 204 and order status changes when successful"""
+    params = {
+        'RESPA_UI_RETURN_URL': 'http%3A%2F%2F127.0.0.1%3A8000%2Fv1',
+        'AUTHCODE': '905EDAC01C9E6921250C21BE23CDC53633A4D66BE7241A3B5DA1D2372234D462',
+        'RETURN_CODE': '0',
+        'ORDER_NUMBER': 'abc123',
+        'SETTLED': '1'
+    }
+    rf = RequestFactory()
+    request = rf.get('/payments/notify/', params)
+    returned = payment_provider.handle_notify_request(request)
+    order_after = Order.objects.get(order_number=params.get('ORDER_NUMBER'))
+    assert order_after.status == Order.CONFIRMED
+    assert isinstance(returned, HttpResponse)
+    assert returned.status_code == 204
+
+
+def test_handle_notify_request_payment_failed(payment_provider, order_with_products):
+    """Test request notify helper returns http 204 and order status changes when payment fails"""
+    params = {
+        'RESPA_UI_RETURN_URL': 'http%3A%2F%2F127.0.0.1%3A8000%2Fv1',
+        'AUTHCODE': 'ED754E8F2E7FE0CC269B9F6A1C197F19B8393F37A1B63BE1E889D53F87A5FCA1',
+        'RETURN_CODE': '1',
+        'ORDER_NUMBER': 'abc123',
+        'SETTLED': '1'
+    }
+    rf = RequestFactory()
+    request = rf.get('/payments/notify/', params)
+    returned = payment_provider.handle_notify_request(request)
+    order_after = Order.objects.get(order_number=params.get('ORDER_NUMBER'))
+    assert order_after.status == Order.REJECTED
+    assert isinstance(returned, HttpResponse)
+    assert returned.status_code == 204
+
+
+def test_handle_notify_request_unknown_error(payment_provider, order_with_products):
+    """Test request notify helper returns http 204 when status code is unknown"""
+    params = {
+        'RESPA_UI_RETURN_URL': 'http%3A%2F%2F127.0.0.1%3A8000%2Fv1',
+        'AUTHCODE': '3CD17A51E89C0A6DDDCA743AFCBD5DC40E8FF8AB97756089E75EC953A19A938C',
+        'RETURN_CODE': '15',
+        'ORDER_NUMBER': 'abc123',
+        'SETTLED': '1'
+    }
+    rf = RequestFactory()
+    request = rf.get('/payments/notify/', params)
+    returned = payment_provider.handle_notify_request(request)
+    assert isinstance(returned, HttpResponse)
+    assert returned.status_code == 204

--- a/payments/tests/test_order.py
+++ b/payments/tests/test_order.py
@@ -1,0 +1,25 @@
+from decimal import Decimal
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_use_django_db(db):
+    pass
+
+
+def test_get_pretax_price_correct(order_with_products):
+    """Test price calculation returns the correct combined taxfree sum for products
+
+    Two hour reservation of two products with a price of 10 should equal 40"""
+    pretax_price = order_with_products.get_pretax_price()
+    assert pretax_price == Decimal('40.00')
+
+
+def test_get_price_correct(order_with_products):
+    """Test price calculation returns the correct combined sum for products
+
+    Two hour reservation of two order lines with a price of 10, plus
+    individual product tax of 24% should equal 49.60"""
+    price = order_with_products.get_price()
+    assert price == Decimal('49.60')

--- a/payments/tests/test_orderline.py
+++ b/payments/tests/test_orderline.py
@@ -1,0 +1,37 @@
+from decimal import Decimal
+
+import pytest
+
+from payments.factories import OrderLineFactory
+
+
+@pytest.fixture(autouse=True)
+def auto_use_django_db(db):
+    pass
+
+
+@pytest.fixture
+def order_line_price(two_hour_reservation):
+    return OrderLineFactory(
+        quantity=1,
+        product__pretax_price=Decimal('10.00'),
+        product__tax_percentage=Decimal('24.00'),
+        order__reservation=two_hour_reservation
+    )
+
+
+def test_get_pretax_price_correct(order_line_price):
+    """Test price calculation works correctly for prices without tax
+
+    Two hour reservation of one product with a price of 10 should equal 40"""
+    pretax_price = order_line_price.get_pretax_price()
+    assert pretax_price == Decimal('20.00')
+
+
+def test_get_price_correct(order_line_price):
+    """Test price calculation works correctly for prices with tax
+
+    Two hour reservation of one product with a price of 10, plus
+    individual product tax of 24% should equal 24.80"""
+    price = order_line_price.get_price()
+    assert price == Decimal('24.80')

--- a/payments/tests/test_utils.py
+++ b/payments/tests/test_utils.py
@@ -1,0 +1,36 @@
+from decimal import Decimal
+
+import pytest
+
+from payments.utils import price_as_sub_units, round_price
+
+
+@pytest.fixture
+def price_even():
+    return Decimal('10.00')
+
+
+@pytest.fixture
+def price_round_up():
+    return Decimal('9.995')
+
+
+@pytest.fixture
+def price_round_down():
+    return Decimal('9.994')
+
+
+def test_price_as_sub_units(price_even):
+    """Test the price is converted to sub units"""
+    even = price_as_sub_units(price_even)
+    assert even == 1000
+
+
+def test_round_price(price_even, price_round_up, price_round_down):
+    """Test the price is round correctly"""
+    even = round_price(price_even)
+    up = round_price(price_round_up)
+    down = round_price(price_round_down)
+    assert even == Decimal('10.00')
+    assert up == Decimal('10.00')
+    assert down == Decimal('9.99')


### PR DESCRIPTION
Prepare a test order fixture in conftest.py that extends the existing resource fixtures
Test payment payload construction and related helpers
Test authcode calculation from payload data and return url params
Test different happy and error paths in payment success and notify handling