### PR TITLE
RESPA-100: UnitIdentifiers listed inline in Unit admin page.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ perf*csv
 /dist
 /src
 .env
+/.vscode

--- a/resources/admin/__init__.py
+++ b/resources/admin/__init__.py
@@ -24,7 +24,7 @@ from ..models import (
     Day, Equipment, EquipmentAlias, EquipmentCategory, Purpose, Reservation,
     ReservationMetadataField, ReservationMetadataSet, Resource,
     ResourceEquipment, ResourceGroup, ResourceImage, ResourceType, TermsOfUse,
-    Unit, UnitAuthorization, UnitGroup, UnitGroupAuthorization)
+    Unit, UnitAuthorization, UnitIdentifier, UnitGroup, UnitGroupAuthorization)
 from munigeo.models import Municipality
 
 logger = logging.getLogger(__name__)
@@ -88,6 +88,12 @@ class ResourceGroupInline(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, a
     extra = 0
 
 
+class UnitIdentifierInline(admin.StackedInline):
+    model = UnitIdentifier
+    fields = ('namespace', 'value')
+    extra = 0
+
+
 class ResourceAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, TranslationAdmin, HttpsFriendlyGeoAdmin):
     inlines = [
         PeriodInline,
@@ -112,7 +118,8 @@ class ResourceAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, Transla
 class UnitAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, FixedGuardedModelAdminMixin,
                 TranslationAdmin, HttpsFriendlyGeoAdmin):
     inlines = [
-        PeriodInline
+        UnitIdentifierInline,
+        PeriodInline,
     ]
     change_list_template = 'admin/units/import_buttons.html'
     import_template = 'admin/units/import_template.html'

--- a/resources/models/unit.py
+++ b/resources/models/unit.py
@@ -177,3 +177,8 @@ class UnitIdentifier(models.Model):
         verbose_name = _("unit identifier")
         verbose_name_plural = _("unit identifiers")
         unique_together = (('namespace', 'value'), ('namespace', 'unit'))
+
+    def __str__(self):
+        return '{namespace}: {value}'.format(
+            namespace=self.namespace, value=self.value
+        )


### PR DESCRIPTION
https://helsinkisolutionoffice.atlassian.net/browse/RESPA-100

Previously Unit identifiers (external ids of the unit in other services) were not visible in the Django admin at all. Now they are listed inline in the Unit detail page.