### PR TITLE
RESPA-112: Update yarn.lock

### DIFF
--- a/respa_admin/yarn.lock
+++ b/respa_admin/yarn.lock
@@ -3341,7 +3341,11 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-jquery@3.3.1, "jquery@>=1.7.1 <4.0.0":
+jquery@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.0.tgz#8de513fa0fa4b2c7d2e48a530e26f0596936efdf"
+
+"jquery@>=1.7.1 <4.0.0":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
 


### PR DESCRIPTION
When updating respa_admin npm dependencies, updated yarn.lock was not committed. Add updated lock file.