### PR TITLE
Migrate from sentry/raven to sentry_sdk

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,7 @@ django-guardian
 Jinja2
 django-jinja
 django-anymail
-raven
+sentry-sdk
 delorean
 freezegun
 python-docx

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
 babel==2.6.0              # via delorean
-certifi==2018.11.29       # via requests
+certifi==2018.11.29       # via requests, sentry-sdk
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
@@ -83,13 +83,13 @@ python-docx==0.8.10
 python3-openid==3.1.0     # via django-allauth
 pytz==2018.9
 pyyaml==5.1               # via database-sanitizer, django-munigeo, django-sanitized-dump
-raven==6.10.0
 requests-cache==0.4.13    # via django-munigeo
 requests-ntlm==1.1.0
 requests-oauthlib==1.2.0  # via django-allauth
 requests==2.21.0
+sentry-sdk==0.9.0
 six==1.12.0
 text-unidecode==1.2       # via faker
 tzlocal==1.5.1            # via delorean
-urllib3==1.24.2           # via requests
+urllib3==1.24.2           # via requests, sentry-sdk
 xlsxwriter==1.1.2

--- a/resources/importer/kirjastot.py
+++ b/resources/importer/kirjastot.py
@@ -3,7 +3,7 @@ import delorean
 import requests
 from django.conf import settings
 from django.db import transaction
-from raven import Client
+from sentry_sdk import capture_message
 from resources.models import Unit
 from typing import Dict, List
 from .base import Importer, register_importer
@@ -59,10 +59,9 @@ def process_varaamo_libraries():
             problems.append(" ".join(["Failed data fetch on library: ", str(varaamo_unit)]))
 
     try:
-        if problems and settings.RAVEN_DSN:
-            # Report problems to Raven/Sentry
-            client = Client(settings.RAVEN_DSN)
-            client.captureMessage("\n".join(problems))
+        if problems:
+            # without Sentry, this will gracefully file the message to /dev/null
+            capture_message("\n".join(problems))
     except AttributeError:
         pass
 

--- a/resources/importer/kirjastot_v2.py
+++ b/resources/importer/kirjastot_v2.py
@@ -12,7 +12,7 @@ from django.db.models import Q
 from resources.models import Unit, UnitIdentifier
 from .base import Importer, register_importer
 
-from raven import Client
+from sentry_sdk import capture_message
 
 from django.conf import settings
 
@@ -72,13 +72,9 @@ def process_varaamo_libraries():
             print("Failed data fetch on library: ", varaamo_unit)
             problems.append(" ".join(["Failed data fetch on library: ", str(varaamo_unit)]))
 
-    try:
-        if problems and settings.RAVEN_DSN:
-            # Report problems to Raven/Sentry
-            client = Client(settings.RAVEN_DSN)
-            client.captureMessage("\n".join(problems))
-    except AttributeError:
-        pass
+    # report problems to Sentry (will fail silently if not available)
+    if problems:
+        capture_message("\n".join(problems))
 
 
 @transaction.atomic

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -2,15 +2,22 @@
 Django settings for respa project.
 """
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+import subprocess
 import environ
 import sentry_sdk
-import subprocess
+from sentry_sdk.integrations.django import DjangoIntegration
 from django.utils.translation import ugettext_lazy as _
 from django.core.exceptions import ImproperlyConfigured
-from sentry_sdk.integrations.django import DjangoIntegration
 
+root = environ.Path(__file__) - 2  # two folders back
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+BASE_DIR = root()
+
+# Location of the fallback version file, used when no repository is available.
+# This is hardcoded as reading it from configuration does not really make
+# sense. It is supposed to be a fallback after all.
+VERSION_FILE = os.path.join(BASE_DIR, '../service_state/deployed_version')
 
 def get_git_revision_hash():
     """
@@ -31,7 +38,7 @@ def get_git_revision_hash():
         git_hash = "no_repository"
     return git_hash.rstrip()
 
-root = environ.Path(__file__) - 2  # two folders back
+
 env = environ.Env(
     DEBUG=(bool, False),
     SECRET_KEY=(str, ''),
@@ -67,8 +74,6 @@ environ.Env.read_env()
 # used for generating links to images, when no request context is available
 # reservation confirmation emails use this
 RESPA_IMAGE_BASE_URL = env('RESPA_IMAGE_BASE_URL')
-
-BASE_DIR = root()
 
 DEBUG_TOOLBAR_CONFIG = {
     'RESULTS_CACHE_SIZE': 100,

--- a/respa_exchange/management/base.py
+++ b/respa_exchange/management/base.py
@@ -39,14 +39,6 @@ def configure_logging(logger="respa_exchange", level=logging.INFO, handler=None)
         datefmt=logging.Formatter.default_time_format
     ))
     logger.addHandler(handler)
-    if hasattr(settings, 'RAVEN_CONFIG') and 'dsn' in settings.RAVEN_CONFIG:
-        from raven.handlers.logging import SentryHandler
-        from raven.conf import setup_logging
-
-        sentry_handler = SentryHandler(settings.RAVEN_CONFIG['dsn'])
-        sentry_handler.setLevel(logging.ERROR)
-        logger.addHandler(sentry_handler)
-        setup_logging(sentry_handler)
 
 
 def select_resources(resources, selected_resources):


### PR DESCRIPTION
Raven has broken because of something to do with SSL. Switching to sentry_sdk unbreaks this.

Some importers had their own sentry captures. I think I translated their behaviour to sentry_sdk. See migrate importers commit.