### PR TITLE
Make bambora base URL configurable

### DIFF
--- a/payments/providers/bambora_payform.py
+++ b/payments/providers/bambora_payform.py
@@ -14,6 +14,7 @@ from .base import PaymentError, PaymentProvider
 logger = logging.getLogger()
 
 # Keys the provider expects to find in the config
+RESPA_PAYMENTS_BAMBORA_API_URL = 'RESPA_PAYMENTS_BAMBORA_API_URL'
 RESPA_PAYMENTS_BAMBORA_API_KEY = 'RESPA_PAYMENTS_BAMBORA_API_KEY'
 RESPA_PAYMENTS_BAMBORA_API_SECRET = 'RESPA_PAYMENTS_BAMBORA_API_SECRET'
 RESPA_PAYMENTS_BAMBORA_PAYMENT_METHODS = 'RESPA_PAYMENTS_BAMBORA_PAYMENT_METHODS'
@@ -30,7 +31,7 @@ class BamboraPayformProvider(PaymentProvider):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.url_payment_api = 'https://payform.bambora.com/pbwapi'
+        self.url_payment_api = self.config.get(RESPA_PAYMENTS_BAMBORA_API_URL)
         self.url_payment_auth = '{}/auth_payment'.format(self.url_payment_api)
         self.url_payment_token = '{}/token/{{token}}'.format(self.url_payment_api)
 
@@ -38,6 +39,7 @@ class BamboraPayformProvider(PaymentProvider):
     def get_config_template() -> dict:
         """Keys and value types what Bambora requires from environment"""
         return {
+            RESPA_PAYMENTS_BAMBORA_API_URL: (str, 'https://payform.bambora.com/pbwapi'),
             RESPA_PAYMENTS_BAMBORA_API_KEY: str,
             RESPA_PAYMENTS_BAMBORA_API_SECRET: str,
             RESPA_PAYMENTS_BAMBORA_PAYMENT_METHODS: list

--- a/payments/providers/bambora_payform.py
+++ b/payments/providers/bambora_payform.py
@@ -186,13 +186,13 @@ class BamboraPayformProvider(PaymentProvider):
             return self.ui_redirect_failure(return_url, order)
         elif return_code == '4':
             logger.debug('Transaction status could not be updated.')
-            # TODO what should we do here? description of the situation:
-            # Transaction status could not be updated after customer returned from the web page of a bank.
-            # Please use the merchant UI to resolve the payment status.
+            order.create_log_entry(
+                'Code 4: Transaction status could not be updated. Use the merchant UI to resolve.'
+            )
             return self.ui_redirect_failure(return_url, order)
         elif return_code == '10':
             logger.debug('Maintenance break.')
-            # TODO what now?
+            order.create_log_entry('Code 10: Bambora Payform maintenance break')
             return self.ui_redirect_failure(return_url, order)
         else:
             logger.warning('Incorrect RETURN_CODE "{}".'.format(return_code))

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -40,8 +40,8 @@ env = environ.Env(
     RESPA_ADMIN_INSTRUCTIONS_URL=(str, ''),
     RESPA_ADMIN_SUPPORT_EMAIL=(str, ''),
     RESPA_ADMIN_VIEW_RESOURCE_URL=(str, ''),
-    RESPA_PAYMENTS_ENABLED = (bool, False),
-    RESPA_PAYMENTS_PROVIDER_CLASS = (str, '')
+    RESPA_PAYMENTS_ENABLED=(bool, False),
+    RESPA_PAYMENTS_PROVIDER_CLASS=(str, '')
 )
 environ.Env.read_env()
 


### PR DESCRIPTION
URL has a default value in provider config template.

Also add some log entries for previously unhandled bambora codes that do not change the Order status. Changing the Order status and/or alerting to take action might be necessary later, but at least there's a better chance somebody notices now.

Refs RESPA-116