### PR TITLE
Add a management command for expiring orders

### DIFF
--- a/payments/management/commands/update_expired_orders.py
+++ b/payments/management/commands/update_expired_orders.py
@@ -1,0 +1,18 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db.transaction import atomic
+
+from payments.models import Order
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Sets "waiting" orders that are too old as "expired".'
+
+    @atomic
+    def handle(self, *args, **options):
+        logger.info('Updating expired orders...')
+        num_of_updated = Order.update_expired()
+        logger.info('Done, {} order(s) got expired.'.format(num_of_updated))

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -41,7 +41,8 @@ env = environ.Env(
     RESPA_ADMIN_SUPPORT_EMAIL=(str, ''),
     RESPA_ADMIN_VIEW_RESOURCE_URL=(str, ''),
     RESPA_PAYMENTS_ENABLED=(bool, False),
-    RESPA_PAYMENTS_PROVIDER_CLASS=(str, '')
+    RESPA_PAYMENTS_PROVIDER_CLASS=(str, ''),
+    RESPA_PAYMENTS_ORDER_MAX_WAITING_TIME=(int, 15),
 )
 environ.Env.read_env()
 
@@ -54,6 +55,9 @@ RESPA_PAYMENTS_ENABLED = env('RESPA_PAYMENTS_ENABLED')
 # Dotted path to the active payment provider class, see payments.providers init.
 # Example value: 'payments.providers.BamboraPayformProvider'
 RESPA_PAYMENTS_PROVIDER_CLASS = env('RESPA_PAYMENTS_PROVIDER_CLASS')
+
+# amount of minutes before orders in state "waiting" will be set to state "expired"
+RESPA_PAYMENTS_ORDER_MAX_WAITING_TIME = env('RESPA_PAYMENTS_ORDER_MAX_WAITING_TIME')
 
 BASE_DIR = root()
 


### PR DESCRIPTION
When run, the command will set orders that are in state "waiting" and too old
to state "expired". Maximum allowed waiting time can be configured in the
settings, by default it is 15min.

Tests will follow separately later.

Refs RESPA-55