### PR TITLE
Unconfigured Respa Admin logo properly disabled.

### DIFF
--- a/respa_admin/views/base.py
+++ b/respa_admin/views/base.py
@@ -7,6 +7,7 @@ class ExtraContextMixin():
         context = super().get_context_data(**kwargs)
         context['INSTRUCTIONS_URL'] = settings.RESPA_ADMIN_INSTRUCTIONS_URL
         context['SUPPORT_EMAIL'] = settings.RESPA_ADMIN_SUPPORT_EMAIL
-        context['logo_url'] = staticfiles_storage.url('respa_admin/img/{0}'.format(settings.RESPA_ADMIN_LOGO))
+        if settings.RESPA_ADMIN_LOGO:
+            context['logo_url'] = staticfiles_storage.url('respa_admin/img/{0}'.format(settings.RESPA_ADMIN_LOGO))
         context['KORO_STYLE'] = settings.RESPA_ADMIN_KORO_STYLE
         return context


### PR DESCRIPTION
Respa Admin logo was displayed as broken img tag if no value was configured. Now the logo is properly hidden.