### PR TITLE
Change payments Order set_state to only allow specific transitions

### DIFF
--- a/payments/api.py
+++ b/payments/api.py
@@ -4,14 +4,14 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
+from payments.exceptions import (
+    DuplicateOrderError, PayloadValidationError, RespaPaymentError, ServiceUnavailableError, UnknownReturnCodeError
+)
 from payments.models import Order, OrderLine, Product
 from resources.api.base import TranslatedModelSerializer, register_view
 from resources.models import Reservation
 
 from .providers import get_payment_provider
-from .providers.bambora_payform import (
-    DuplicateOrderError, PayloadValidationError, ServiceUnavailableError, UnknownReturnCodeError
-)
 
 
 class ProductSerializer(TranslatedModelSerializer):
@@ -108,6 +108,9 @@ class OrderSerializer(OrderSerializerBase):
         except ServiceUnavailableError as sue:
             raise exceptions.APIException(detail=str(sue),
                                           code=status.HTTP_503_SERVICE_UNAVAILABLE)
+        except RespaPaymentError as pe:
+            raise exceptions.APIException(detail=str(pe),
+                                          code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         return order
 

--- a/payments/exceptions.py
+++ b/payments/exceptions.py
@@ -1,0 +1,24 @@
+
+
+class RespaPaymentError(Exception):
+    """Base for payment specific exceptions"""
+
+
+class OrderStateTransitionError(RespaPaymentError):
+    """Attempting an Order from-to -state transition that isn't allowed"""
+
+
+class ServiceUnavailableError(RespaPaymentError):
+    """When payment service is unreachable, offline for maintenance etc"""
+
+
+class PayloadValidationError(RespaPaymentError):
+    """When something is wrong or missing in the posted payment payload data"""
+
+
+class DuplicateOrderError(RespaPaymentError):
+    """If order with the same ID has already been previously posted"""
+
+
+class UnknownReturnCodeError(RespaPaymentError):
+    """If payment service returns a status code that is not recognized by the handler"""

--- a/payments/providers/base.py
+++ b/payments/providers/base.py
@@ -76,7 +76,3 @@ class PaymentProvider:
         if order:
             params['order_id'] = order.id
         return redirect('{}?{}'.format(return_url, urlencode(params)))
-
-
-class PaymentError(Exception):
-    """Base for payment specific exceptions"""

--- a/payments/tests/test_order_log_entry.py
+++ b/payments/tests/test_order_log_entry.py
@@ -27,7 +27,7 @@ def test_order_log_entry_created_on_order_creation(order_with_products):
     assert order_log_entry.state_change == Order.WAITING
 
 
-@pytest.mark.parametrize('new_state', (Order.REJECTED, Order.CONFIRMED, Order.EXPIRED))
+@pytest.mark.parametrize('new_state', (Order.REJECTED, Order.CONFIRMED, Order.EXPIRED, Order.CANCELLED))
 def test_order_log_entry_created_on_order_set_state(order_with_products, new_state):
     order_with_products.set_state(new_state)
 
@@ -36,11 +36,10 @@ def test_order_log_entry_created_on_order_set_state(order_with_products, new_sta
     assert order_log_entry.state_change == new_state
 
 
-@pytest.mark.parametrize('state', (Order.WAITING, Order.REJECTED, Order.CONFIRMED, Order.EXPIRED))
-def test_order_log_entry_not_created_on_order_set_state_when_state_stays_same(two_hour_reservation, state):
-    order = OrderFactory(reservation=two_hour_reservation, state=state)
+def test_order_log_entry_not_created_on_order_set_state_when_state_stays_same(two_hour_reservation):
+    order = OrderFactory(reservation=two_hour_reservation, state=Order.WAITING)
     assert OrderLogEntry.objects.count() == 1
 
-    order.set_state(state)
+    order.set_state(Order.WAITING)
 
     assert OrderLogEntry.objects.count() == 1


### PR DESCRIPTION
Add test for order create reservation state restrictions
Move payment related exceptions into a centralized location

Contains what was discussed last week about it not making sense to check that order is in "waiting_for_payment" -state outside of everywhere order state is being set. Also a test for not allowing to create orders for reservations that aren't "waiting_for_payment".

Refs RESPA-117