### PR TITLE
Payment notifications

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -245,9 +245,12 @@ class Order(models.Model):
         if new_state == old_state:
             return
 
-        if old_state != Order.WAITING:
-            raise OrderStateTransitionError('Cannot set order {} state, it is in an invalid state "{}".',
-                                            self.order_number, old_state)
+        if old_state != Order.WAITING and not (old_state == Order.CONFIRMED and new_state == Order.CANCELLED):
+            raise OrderStateTransitionError(
+                'Cannot set order {} state to "{}", it is in an invalid state "{}".'.format(
+                    self.order_number, new_state, old_state
+                )
+            )
 
         self.state = new_state
 

--- a/payments/models.py
+++ b/payments/models.py
@@ -5,9 +5,12 @@ from django.conf import settings
 from django.core.validators import MinValueValidator
 from django.db import models
 from django.db.models import OuterRef, Q, Subquery
+from django.utils import translation
+from django.utils.formats import localize
 from django.utils.functional import cached_property
 from django.utils.timezone import now, utc
 from django.utils.translation import ugettext_lazy as _
+from rest_framework import serializers
 
 from resources.models import Reservation, Resource
 from resources.models.utils import generate_id
@@ -110,8 +113,17 @@ class Product(models.Model):
     def delete(self, *args, **kwargs):
         Product.objects.filter(id=self.id).update(archived_at=now())
 
-    def get_price(self):
-        return round_price(self.pretax_price * (1 + Decimal(self.tax_percentage) / 100))
+    def get_price(self, rounded: bool = True) -> Decimal:
+        price = self.pretax_price * (1 + Decimal(self.tax_percentage) / 100)
+        if rounded:
+            price = round_price(price)
+        return price
+
+    def get_tax_amount(self, rounded: bool = True) -> Decimal:
+        tax_amount = self.get_price(rounded=rounded) - self.pretax_price
+        if rounded:
+            tax_amount = round_price(tax_amount)
+        return tax_amount
 
     def get_pretax_price_for_time_range(self, begin: datetime, end: datetime, rounded: bool = True) -> Decimal:
         assert begin < end
@@ -222,6 +234,10 @@ class Order(models.Model):
     def get_price(self) -> Decimal:
         return sum(order_line.get_price() for order_line in self.order_lines.all())
 
+    def get_tax_amount(self) -> Decimal:
+        tax_amount = self.get_price() - self.get_pretax_price()
+        return tax_amount
+
     def set_state(self, new_state: str, log_message: str = None, save: bool = True) -> None:
         assert new_state in (Order.WAITING, Order.CONFIRMED, Order.REJECTED, Order.EXPIRED, Order.CANCELLED)
 
@@ -248,6 +264,10 @@ class Order(models.Model):
     def create_log_entry(self, message: str = None, state_change: str = None) -> None:
         OrderLogEntry.objects.create(order=self, state_change=state_change or '', message=message or '')
 
+    def get_notification_context(self, language_code):
+        with translation.override(language_code):
+            return NotificationOrderSerializer(self).data
+
 
 class OrderLine(models.Model):
     order = models.ForeignKey(Order, verbose_name=_('order'), related_name='order_lines', on_delete=models.CASCADE)
@@ -271,6 +291,10 @@ class OrderLine(models.Model):
     def get_price(self) -> Decimal:
         return self.product.get_price_for_reservation(self.order.reservation) * self.quantity
 
+    def get_tax_amount(self) -> Decimal:
+        tax_amount = self.get_price() - self.get_pretax_price()
+        return tax_amount
+
 
 class OrderLogEntry(models.Model):
     order = models.ForeignKey(
@@ -291,3 +315,47 @@ class OrderLogEntry(models.Model):
         return '{} order {} state change {} message {}'.format(
             self.timestamp, self.order_id, self.state_change or None, self.message or None
         )
+
+
+class LocalizedSerializerField(serializers.Field):
+    def __init__(self, *args, **kwargs):
+        kwargs['read_only'] = True
+        super().__init__(*args, **kwargs)
+
+    def to_representation(self, value):
+        return localize(value)
+
+
+class NotificationProductSerializer(serializers.ModelSerializer):
+    id = serializers.ReadOnlyField(source='product_id')
+    tax_percentage = LocalizedSerializerField()
+    price = LocalizedSerializerField(source='get_price')
+    type_display = serializers.ReadOnlyField(source='get_type_display')
+    price_type_display = serializers.ReadOnlyField(source='get_price_type_display')
+
+    class Meta:
+        model = Product
+        fields = ('id', 'name', 'description', 'type', 'type_display', 'price_type', 'price_type_display',
+                  'tax_percentage', 'price')
+
+
+class NotificationOrderLineSerializer(serializers.ModelSerializer):
+    product = NotificationProductSerializer()
+    price = LocalizedSerializerField(source='get_price')
+    tax_amount = LocalizedSerializerField(source='get_tax_amount')
+
+    class Meta:
+        model = OrderLine
+        fields = ('product', 'quantity', 'price', 'tax_amount')
+
+
+class NotificationOrderSerializer(serializers.ModelSerializer):
+    id = serializers.ReadOnlyField(source='order_number')
+    created_at = LocalizedSerializerField()
+    order_lines = NotificationOrderLineSerializer(many=True)
+    price = LocalizedSerializerField(source='get_price')
+    tax_amount = LocalizedSerializerField(source='get_tax_amount')
+
+    class Meta:
+        model = Order
+        fields = ('id', 'order_lines', 'price', 'tax_amount', 'created_at')

--- a/payments/tests/test_notifications.py
+++ b/payments/tests/test_notifications.py
@@ -1,0 +1,127 @@
+import pytest
+from django.core import mail
+from django.test import override_settings
+from django.utils import translation
+
+from notifications.models import NotificationTemplate, NotificationType
+from notifications.tests.utils import check_received_mail_exists
+from resources.models import Reservation
+
+from ..factories import OrderWithOrderLinesFactory
+from ..models import Order
+
+
+def localize_decimal(d):
+    return str(d).replace('.', ',')
+
+
+def get_body_with_all_template_vars():
+    template_vars = (
+        'order.id',
+        'order.created_at',
+        'order.price',
+        'order.tax_amount',
+        'order_line.price',
+        'order_line.tax_amount',
+        'order_line.quantity',
+        'product.id',
+        'product.name',
+        'product.description',
+        'product.type',
+        'product.type_display',
+        'product.price_type',
+        'product.price_type_display',
+    )
+    body = '{% set order_line=order.order_lines[0] %}{% set product=order_line.product %}\n'
+    for template_var in template_vars:
+        body += '{{ %s }}\n' % template_var
+    return body
+
+
+def get_expected_strings(order):
+    order_line = order.order_lines.first()
+    product = order_line.product
+    return (
+        order.order_number,
+        str(order.created_at.year),
+        localize_decimal(order.get_price()),
+        localize_decimal(order.get_tax_amount()),
+        localize_decimal(order_line.get_price()),
+        localize_decimal(order_line.get_tax_amount()),
+        str(order_line.quantity),
+        product.product_id,
+        product.name,
+        product.description,
+        product.type,
+        product.get_type_display(),
+        product.price_type,
+        product.get_price_type_display(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def reservation_created_notification():
+    NotificationTemplate.objects.filter(type=NotificationType.RESERVATION_CREATED).delete()
+    with translation.override('fi'):
+        return NotificationTemplate.objects.create(
+            type=NotificationType.RESERVATION_CREATED,
+            short_message='Reservation created short message.',
+            subject='Reservation created subject.',
+            body='Reservation created body. \n' + get_body_with_all_template_vars()
+        )
+
+
+@pytest.fixture(autouse=True)
+def reservation_cancelled_notification():
+    NotificationTemplate.objects.filter(type=NotificationType.RESERVATION_CANCELLED).delete()
+    with translation.override('fi'):
+        return NotificationTemplate.objects.create(
+            type=NotificationType.RESERVATION_CANCELLED,
+            short_message='Reservation cancelled short message.',
+            subject='Reservation cancelled subject.',
+            body='Reservation cancelled body. \n' + get_body_with_all_template_vars()
+        )
+
+
+@pytest.mark.django_db
+@override_settings(RESPA_MAILS_ENABLED=True)
+def test_reservation_created_notification(order_with_products):
+    user = order_with_products.reservation.user
+    user.preferred_language = 'fi'
+    user.save()
+
+    order_with_products.set_state(Order.CONFIRMED)
+
+    assert len(mail.outbox) == 1
+    check_received_mail_exists(
+        'Reservation created subject.',
+        order_with_products.reservation.user.email,
+        get_expected_strings(order_with_products),
+    )
+
+
+@pytest.mark.parametrize('order_state, notification_expected', (
+    (Order.REJECTED, False),
+    (Order.EXPIRED, False),
+    (Order.CANCELLED, True),
+))
+@pytest.mark.django_db
+@override_settings(RESPA_MAILS_ENABLED=True)
+def test_reservation_cancelled_notification(order_with_products, order_state, notification_expected):
+    user = order_with_products.reservation.user
+    user.preferred_language = 'fi'
+    user.save()
+    if order_state == Order.CANCELLED:
+        Reservation.objects.filter(id=order_with_products.reservation.id).update(state=Reservation.CONFIRMED)
+
+    order_with_products.set_state(order_state)
+
+    if notification_expected:
+        assert len(mail.outbox) == 1
+        check_received_mail_exists(
+            'Reservation cancelled subject.',
+            order_with_products.reservation.user.email,
+            get_expected_strings(order_with_products),
+        )
+    else:
+        assert len(mail.outbox) == 0

--- a/payments/tests/test_order.py
+++ b/payments/tests/test_order.py
@@ -54,7 +54,6 @@ def test_set_state_sets_reservation_state(two_hour_reservation, order_state, exp
     (Order.REJECTED, Order.CANCELLED),
     (Order.CONFIRMED, Order.REJECTED),
     (Order.CONFIRMED, Order.EXPIRED),
-    (Order.CONFIRMED, Order.CANCELLED),
     (Order.EXPIRED, Order.REJECTED),
     (Order.EXPIRED, Order.CONFIRMED),
     (Order.EXPIRED, Order.CANCELLED),
@@ -66,3 +65,16 @@ def test_set_state_denied_transitions(two_hour_reservation, state, new_state):
     order = OrderFactory(reservation=two_hour_reservation, state=state)
     with pytest.raises(OrderStateTransitionError):
         order.set_state(new_state)
+
+
+@pytest.mark.parametrize('state, new_state', (
+    (Order.WAITING, Order.CONFIRMED),
+    (Order.WAITING, Order.EXPIRED),
+    (Order.WAITING, Order.CANCELLED),
+    (Order.WAITING, Order.REJECTED),
+    (Order.CONFIRMED, Order.CANCELLED),
+))
+def test_set_state_allowed_transitions(two_hour_reservation, state, new_state):
+    order = OrderFactory(reservation=two_hour_reservation, state=state)
+    order.set_state(new_state)
+    assert order.state == new_state

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -377,14 +377,25 @@ class Reservation(ModifiableModel):
                 'begin_dt': self.begin,
                 'end_dt': self.end,
                 'time_range': self.format_time(),
-                'number_of_participants': self.number_of_participants,
-                'host_name': self.host_name,
                 'reserver_name': reserver_name,
-                'event_subject': self.event_subject,
-                'event_description': self.event_description,
                 'reserver_email_address': reserver_email_address,
-                'reserver_phone_number': self.reserver_phone_number,
             }
+            directly_included_fields = (
+                'number_of_participants',
+                'host_name',
+                'event_subject',
+                'event_description',
+                'reserver_phone_number',
+                'billing_first_name',
+                'billing_last_name',
+                'billing_email_address',
+                'billing_phone_number',
+                'billing_address_street',
+                'billing_address_zip',
+                'billing_address_city',
+            )
+            for field in directly_included_fields:
+                context[field] = getattr(self, field)
             if self.resource.unit:
                 context['unit'] = self.resource.unit.name
                 context['unit_id'] = self.resource.unit.id

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -408,6 +408,10 @@ class Reservation(ModifiableModel):
                 if ground_plan_image_url:
                     context['resource_ground_plan_image_url'] = ground_plan_image_url
 
+            order = getattr(self, 'order', None)
+            if order:
+                context['order'] = order.get_notification_context(language_code)
+
         return context
 
     def send_reservation_mail(self, notification_type, user=None, attachments=None):


### PR DESCRIPTION
Added order and billing data to reservation notifications' context, and changed reservation cancelled notifications to be sent always when there is a cancelled order involved.

Refs RESPA-123