### PR TITLE
RESPA-156: Fix Respa Admin not allowing more than 10 opening hour periods to be saved for a resource

### DIFF
--- a/respa_admin/static_src/js/resourceForm.js
+++ b/respa_admin/static_src/js/resourceForm.js
@@ -65,7 +65,7 @@ function setPeriodAndDayItems() {
   let $daysList = $servedPeriodItem.find('#period-days-list')[0].children;
   let $servedDayItem = $daysList[$daysList.length-1];
 
-  emptyDayItem = $($servedDayItem).clone();
+  emptyDayItem = $($servedDayItem).clone(true);
   emptyDayItem.removeClass('original-day');  // added days are not original. used for sorting formset indices.
   emptyPeriodItem = $($servedPeriodItem).clone();
 

--- a/respa_admin/static_src/js/resourceFormPeriods.js
+++ b/respa_admin/static_src/js/resourceFormPeriods.js
@@ -84,7 +84,7 @@ export function sortPeriodDays($periodItem) {
 function updatePeriodDaysIndices($periodItem) {
   let originalDaysList = $periodItem.find('.weekday-row.original-day');
   let newDaysList = $periodItem.find('.weekday-row:not(.original-day)');
-  let periodIdNum = $periodItem[0].id.match(/[0-9]/)[0];
+  let periodIdNum = $periodItem[0].id.match(/[0-9]+/)[0];
 
   const setIndex = function (dayIndex, day) {
     $(day).attr('id', $(day).attr('id').replace(/-(\d+)-(\d+)/, '-' + periodIdNum + '-' + dayIndex));

--- a/respa_admin/static_src/js/resourceFormPeriods.js
+++ b/respa_admin/static_src/js/resourceFormPeriods.js
@@ -307,7 +307,7 @@ function addDay(daysList, weekday) {
   let emptyDayItem = getEmptyDayItem();
 
   if (emptyDayItem) {
-    let newDayItem = emptyDayItem.clone();
+    let newDayItem = emptyDayItem.clone(true);
 
     newDayItem.find("[id*='-weekday']").val(weekday);
     daysList.append(newDayItem);
@@ -369,6 +369,7 @@ function removePeriodEventHandlers(periodItem) {
   periodItem.find(".delete-time").off();
   periodItem.find(".copy-time-btn").off();
   periodItem.find("[id^='date-input']").off();
+  periodItem.find('.copy-next').off();
 
 }
 


### PR DESCRIPTION
https://helsinkisolutionoffice.atlassian.net/browse/RESPA-156

A bug in the opening hour editor in Respa Admin prevented more than 10 periods to be added. The bug is fixed.

PR also includes a fix to the opening hour "copy to next" button, which was not working for newly created periods.