### PR TITLE
RESPA-171 | Support for first and last name search

### DIFF
--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -479,8 +479,14 @@ class ReservationFilterSet(django_filters.rest_framework.FilterSet):
         # restrict results to reservations the user has right to see
         queryset = queryset.extra_fields_visible(user)
 
+        fields = ('user__first_name', 'user__last_name', 'user__email',
+                  'reserver_name', 'reserver_email_address', 'reserver_phone_number')
+        conditions = []
+        for field in fields:
+            conditions.append(Q(**{field + '__icontains': value}))
+
         # assume that first_name and last_name were provided if empty space was found
-        if ' ' in value:
+        if ' ' in value and value.count(' ') == 1:
             name1, name2 = value.split()
             filters = Q(
                 user__first_name__icontains=name1,
@@ -489,13 +495,8 @@ class ReservationFilterSet(django_filters.rest_framework.FilterSet):
                 user__first_name__icontains=name2,
                 user__last_name__icontains=name1,
             )
-            return queryset.filter(filters)
+            conditions.append(filters)
 
-        fields = ('user__first_name', 'user__last_name', 'user__email',
-                  'reserver_name', 'reserver_email_address', 'reserver_phone_number')
-        conditions = []
-        for field in fields:
-            conditions.append(Q(**{field + '__icontains': value}))
         return queryset.filter(reduce(operator.or_, conditions))
 
 

--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -479,11 +479,24 @@ class ReservationFilterSet(django_filters.rest_framework.FilterSet):
         # restrict results to reservations the user has right to see
         queryset = queryset.extra_fields_visible(user)
 
+        # assume that first_name and last_name were provided if empty space was found
+        if ' ' in value:
+            name1, name2 = value.split()
+            filters = Q(
+                user__first_name__icontains=name1,
+                user__last_name__icontains=name2,
+            ) | Q(
+                user__first_name__icontains=name2,
+                user__last_name__icontains=name1,
+            )
+            return queryset.filter(filters)
+
         fields = ('user__first_name', 'user__last_name', 'user__email',
                   'reserver_name', 'reserver_email_address', 'reserver_phone_number')
         conditions = []
         for field in fields:
             conditions.append(Q(**{field + '__icontains': value}))
+            print(conditions)
         return queryset.filter(reduce(operator.or_, conditions))
 
 

--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -496,7 +496,6 @@ class ReservationFilterSet(django_filters.rest_framework.FilterSet):
         conditions = []
         for field in fields:
             conditions.append(Q(**{field + '__icontains': value}))
-            print(conditions)
         return queryset.filter(reduce(operator.or_, conditions))
 
 

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -1978,6 +1978,7 @@ def test_include_resource_detail(api_client, resource_in_unit, reservation, list
     'reserver_info_search=martta',
     'reserver_info_search=brendan',
     'reserver_info_search=neutra',
+    'reserver_info_search=brendan+neutra',
     'reserver_info_search=brendan@neutra.com',
 ))
 @pytest.mark.django_db
@@ -1998,6 +1999,10 @@ def test_reserver_info_search_filter(staff_api_client, staff_user, reservation, 
     # if no value given for the filter, it should return all reservations
     if filtering == 'reserver_info_search=':
         assert_response_objects(response, [reservation, reservation2, reservation3])
+
+    # providing query param including space assumes that first_name and last_name are being provided
+    elif filtering == 'reserver_info_search=brendan+neutra':
+        assert_response_objects(response, [reservation3])
 
     # martta is reserver_name in first reservation fixture, which has another unit assigned,
     # hence our staff_user should not have permissions to view reservations' users' info


### PR DESCRIPTION
Changed `filter_reserver_info_search` method to also support both first name **and** last name. Changed method works as follows:

If space character has been found in query parameter (t.ex. oskari tiala), query parameter will be split by space, into `oskari` and `tiala`, and reservations are filtered with `first_name='oskari', last_name='tiala' OR first_name='tiala', last_name='oskari'`, as we really can’t know in which order the names are provided. The search is case insensitive.