### PR TITLE
RESPA-170 | Modify iCal file

### DIFF
--- a/resources/models/utils.py
+++ b/resources/models/utils.py
@@ -231,8 +231,6 @@ def build_reservations_ical_file(reservations):
     """
 
     cal = Calendar()
-    cal['X-WR-CALNAME'] = vText('RESPA')
-    cal['name'] = vText('RESPA')
     for reservation in reservations:
         event = Event()
         begin_utc = timezone.localtime(reservation.begin, timezone.utc)


### PR DESCRIPTION
https://helsinkisolutionoffice.atlassian.net/browse/RESPA-170

Remove the following lines from `build_reservations_ical_file()` utility function:

```
NAME:RESPA
X-WR-CALNAME:RESPA
```
When iCal file was imported in Outlook, these lines seemed to make it create a new calendar for the calendar object. In Google calendar, it seems to behave as expected, both with and without these lines. 

After removal, I tested that `build_reservations_ical_file()` returned a valid iCalendar file, but this should be tested in staging environment if possible.