### PR TITLE
RESPA-155 | Fix: Use distinct on unit queryset

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1196,8 +1196,8 @@ msgstr "Henkilökunnan tili"
 msgid "Allows user to grant permissions to units"
 msgstr "Antaa käyttäjän myöntää käyttöoikeuksia toimipisteille"
 
-msgid "You can't add permissions to unit you are not admin of"
-msgstr "Et voi antaa käyttöoikeuksia toimipisteelle, jonka ylläpitäjä et ole"
+msgid "You can't add, change or delete permissions to unit you are not admin of"
+msgstr "Et voi lisätä, poistaa tai muokata käyttöoikeuksia toimipisteelle, jonka ylläpitäjä et ole"
 
 msgid "Log out"
 msgstr "Kirjaudu ulos"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -913,8 +913,8 @@ msgstr "Personalkonto"
 msgid "Allows user to grant permissions to units"
 msgstr "Tillåter användare att bevilja behörigheter till behörigheter"
 
-msgid "You can't add permissions to unit you are not admin of"
-msgstr "Du kan inte bevilja behörigheter till enheter som du inte är administratör för"
+msgid "You can't add, change or delete permissions to unit you are not admin of"
+msgstr "Du kan inte bevilja, redigera eller radera behörigheter till enheter som du inte är administratör för"
 
 msgid "Instructions"
 msgstr "Instruktioner"

--- a/respa_admin/static_src/styles/form/form-utils.scss
+++ b/respa_admin/static_src/styles/form/form-utils.scss
@@ -46,6 +46,20 @@ $input-height-default: 50px;
   }
 }
 
+.select-dropdown-disabled {
+  @extend .select-dropdown;
+  background-color: #e5e5e5;
+
+  &:hover {
+    background-color: #e5e5e5;
+    cursor: not-allowed;
+  }
+
+  span, select {
+    color: #999898;
+  }
+}
+
 // styling for input label
 
 .input-label {

--- a/respa_admin/static_src/styles/page-user-management.scss
+++ b/respa_admin/static_src/styles/page-user-management.scss
@@ -1,48 +1,58 @@
 .user-info {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: center;
-    margin-top: 35px;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  margin-top: 35px;
 }
 
-.cancel-button {
-    margin-left: 10px;
-    background-color: transparent;
-    color: #d21220;
-    padding: $padding-large-vertical 24px;
-    font-weight: 500;
+.cancel-button, .remove-button {
+  margin-left: 10px;
+  background-color: transparent;
+  color: #d21220;
+  padding: $padding-large-vertical 24px;
+  font-weight: 500;
+}
+
+.remove-button-disabled {
+  @extend .remove-button;
+  color: #999898;
+
+  &:hover {
+    color: #999898;
+    cursor: not-allowed;
+  }
 }
 
 .button-div {
-    margin-top: 50px;
+  margin-top: 50px;
 }
 
 .full-width-table {
-    width: 100%;
+  width: 100%;
 }
 
 .table-cell-centered {
-    text-align: center;
-    padding-top: 5px;
-    vertical-align: top;
+  text-align: center;
+  padding-top: 5px;
+  vertical-align: top;
 }
 
 .table-header {
-    text-align: center;
-    padding-top: 30px;
-    padding-bottom: 10px;
+  text-align: center;
+  padding-top: 30px;
+  padding-bottom: 10px;
 }
 
 .hidden-delete-checkbox {
-    display: none;
+  display: none;
 }
 
 .dropdown-block {
-    display: block;
+  display: block;
 }
 
 .form-error-block {
-    text-align: center;
-    font-weight: bold;
-    color: red;
+  text-align: center;
+  font-weight: bold;
+  color: red;
 }

--- a/respa_admin/templates/respa_admin/forms/_select.html
+++ b/respa_admin/templates/respa_admin/forms/_select.html
@@ -4,9 +4,16 @@
             {{ field.label }}{% if field.field.required %}*{% endif %}
         </label>
     {% endif %}
-    <div class="select-dropdown btn btn-primary {% if extra_classes %}{{ extra_classes }}{% endif %}">
-        {{ field }}
-        <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
-    </div>
+    {% if disabled %}
+        <div class="select-dropdown-disabled btn-primary {% if extra_classes %}{{ extra_classes }}{% endif %}">
+            {{ field }}
+            <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
+        </div>
+    {% else %}
+        <div class="select-dropdown btn btn-primary {% if extra_classes %}{{ extra_classes }}{% endif %}">
+            {{ field }}
+            <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
+        </div>
+    {% endif %}
     {% include "respa_admin/forms/_errors.html" with field=field %}
 </div>

--- a/respa_admin/templates/respa_admin/resources/form/_permissions.html
+++ b/respa_admin/templates/respa_admin/resources/form/_permissions.html
@@ -19,17 +19,17 @@
             <tr id="permission-item-{{id}}" class="permission-item">
                 {{ form.id }}
                 <td class="table-cell-centered">
-                    {% include "respa_admin/forms/_select.html" with field=form.subject inline=False skip_label=True extra_classes='dropdown-block' %}
+                    {% include "respa_admin/forms/_select.html" with field=form.subject inline=False skip_label=True extra_classes='dropdown-block' disabled=form.is_disabled %}
                 </td>
                 <td class="table-cell-centered">
-                    {% include "respa_admin/forms/_select.html" with field=form.level inline=True skip_label=True extra_classes='dropdown-block' %}
+                    {% include "respa_admin/forms/_select.html" with field=form.level inline=True skip_label=True extra_classes='dropdown-block' disabled=form.is_disabled %}
                 </td>
                     {{ form.authorized }}
                 <td class="table-cell-centered">
                     {{ form.can_approve_reservation }}
                 </td>
                 <td class="table-cell-centered">
-                    <button class="remove-permission btn cancel-button" type="button">{% trans "Delete Item" %}</button>
+                    <button class="remove-permission btn remove-button{% if form.is_disabled %}-disabled{% endif%}" type="button" {% if form.is_disabled %}disabled{% endif %}>{% trans "Delete Item" %}</button>
                     <span class="hidden-delete-checkbox">{{ form.DELETE }}</span>
                 </td>
                 {% endwith %}

--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -187,7 +187,7 @@ class ManageUserPermissionsListView(ExtraContextMixin, ListView):
                                    UnitGroupAuthorizationLevel.admin,
                                })
         all_available_units = self.model.objects.filter(unit_filters | unit_group_filters).prefetch_related('authorizations')
-        return all_available_units.exclude(authorizations__authorized__isnull=True)
+        return all_available_units.exclude(authorizations__authorized__isnull=True).distinct('name')
 
     def get_queryset(self):
         qs = self.get_all_available_units()


### PR DESCRIPTION
- Use distinct on unit queryset to avoid duplicate units showing up.
- Block user from deleting or manipulating units that they don't have authorization to
- Indicate such units in the UI