### PR TITLE
Fix API document version numbering

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: Respa
   description: The Respa API provides categorized data on resources available for reservation within a city or metropolitan area
     and enables the reservation of these resources. The API provides data in the JSON format, in a RESTful fashion.
-  version: v1
+  version: 1.5.1
 servers:
 - url: https://api.hel.fi/respa/v1
 tags:


### PR DESCRIPTION
Until now, the `version` field has been used to describe the Respa API implementation version, which is incorrect usage according to the [OpenAPI spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#info-object): 

> The version of the OpenAPI document (which is distinct from the OpenAPI Specification version or the API implementation version)

The OpenAPI spec does not guide the user in how document version numbering should be implemented, so I propose the following format
- MAJOR version when you document backwards incompatible changes in the API
- MINOR version when you document added backwards compatible features
- PATCH version when you correct errors in the documentation

The version number has been updated to reflect the commit history of this document.

Alternative suggestions are welcome!