### PR TITLE
RESPA-52 | Change login view texts

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1254,14 +1254,14 @@ msgstr ""
 msgid "Login failed"
 msgstr "Kirjautuminen epäonnistui"
 
-msgid "Log in with Helsinki account"
-msgstr "Kirjaudu Helsinki-tunnuksella"
-
 msgid "Username"
 msgstr "Käyttäjätunnus"
 
 msgid "Password"
 msgstr "Salasana"
+
+msgid "Log in with Django account"
+msgstr "Kirjaudu sisään Django-tunnuksella"
 
 msgid "All resources I manage"
 msgstr "Kaikki hallitsemani resurssit"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -968,9 +968,6 @@ msgstr ""
 msgid "Login failed"
 msgstr "Inloggningen misslyckades"
 
-msgid "Log in with Helsinki account"
-msgstr "Logga in med Helsinki konto"
-
 #, fuzzy
 #| msgid "username"
 msgid "Username"
@@ -980,6 +977,9 @@ msgstr "användarnamn"
 #| msgid "password"
 msgid "Password"
 msgstr "lösenord"
+
+msgid "Log in with Django account"
+msgstr "Logga in med Django konto"
 
 msgid "All resources I manage"
 msgstr "Alla mina resurser"

--- a/respa_admin/templates/respa_admin/login.html
+++ b/respa_admin/templates/respa_admin/login.html
@@ -36,7 +36,7 @@
                 class="btn btn-primary"
                 type="button"
             >
-                {% trans "Log in with Helsinki account" %}
+                {% trans "Log in" %}
             </a>
             {% endif %}
 
@@ -65,7 +65,7 @@
                     >
                 </div>
                 <button type="submit" class="btn btn-primary">
-                    {% trans "Log in" %}
+                    {% trans "Log in with Django account" %}
                 </button>
             </form>
             {% endif %}


### PR DESCRIPTION
- Change login page texts/translations:
    - `Log in with Helsinki account` -> `Log in`
    - `Log in` -> `Log in with Django account`

Logout page is served from Tunnistamo, so that remains untouched.