### PR TITLE
RESPA-185 | Add permissions for unit manager

### DIFF
--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -149,22 +149,29 @@ with the scope of authorization and the authorized roles.
 General Administrator role is not bound to any Unit or Unit Group and so
 their permissions are unscoped.
 
-================================ ============ ====== ======= ====== ======
-**Permission**                   **Scope**    **GA** **UGA** **UA** **UM**
--------------------------------- ------------ ------ ------- ------ ------
-can_login_to_respa_admin         General        X       X      X      X
-can_modify_resources             Unit           X       X      X      X
-can_modify_unit                  Unit           X       X      X      X
-can_access_permissions_view      General        X       X      X
-can_search_users                 General        X       X      X
-can_manage_resource_perms        Unit           X       X      X
-can_manage_auth_of_unit          Unit           X       X      X
-can_create_resource_to_unit      Unit           X       X      X
-can_delete_resource_of_unit      Unit           X       X      X
-can_manage_auth_of_unit_group    Unit Group     X       X
-can_create_unit_to_group         Unit Group     X       X
-can_delete_unit_of_group         Unit Group     X       X
-================================ ============ ====== ======= ====== ======
+====================================== ============ ====== ======= ====== ======
+**Permission**                         **Scope**    **GA** **UGA** **UA** **UM**
+-------------------------------------- ------------ ------ ------- ------ ------
+can_login_to_respa_admin               General        X       X      X      X
+can_modify_resources                   Unit           X       X      X      X
+can_modify_unit                        Unit           X       X      X      X
+can_access_permissions_view            General        X       X      X
+can_search_users                       General        X       X      X
+can_manage_resource_perms              Unit           X       X      X
+can_manage_auth_of_unit                Unit           X       X      X
+can_create_resource_to_unit            Unit           X       X      X
+can_delete_resource_of_unit            Unit           X       X      X
+can_make_reservations                  Unit                                 X
+can_modify_reservations                Unit                                 X
+can_ignore_opening_hours               Unit                                 X
+can_view_reservation_access_code       Unit                                 X
+can_view_reservation_extra_fields      Unit                                 X
+can_access_reservation_comments        Unit                                 X
+can_view_reservation_catering_orders   Unit                                 X
+can_manage_auth_of_unit_group          Unit Group     X       X
+can_create_unit_to_group               Unit Group     X       X
+can_delete_unit_of_group               Unit Group     X       X
+====================================== ============ ====== ======= ====== ======
 
 Definitions of the permissions:
 

--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -274,8 +274,10 @@ class ReservationSerializer(ExtraDataMixin, TranslatedModelSerializer, munigeo_a
             })
 
         # Show the comments field and the user object only for staff
-        if not resource.is_admin(user):
+        if not resource.is_admin(user) and not resource.can_access_reservation_comments(user):
             del data['comments']
+
+        if not resource.is_admin(user):
             del data['user']
 
         if instance.are_extra_fields_visible(user):

--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -273,7 +273,6 @@ class ReservationSerializer(ExtraDataMixin, TranslatedModelSerializer, munigeo_a
                 'created_at': instance.created_at
             })
 
-        # Show the comments field and the user object only for staff
         if not resource.is_admin(user) and not resource.can_access_reservation_comments(user):
             del data['comments']
 

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -299,11 +299,12 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
         if begin.date() != end.date():
             raise ValidationError(_("You cannot make a multi day reservation"))
 
-        opening_hours = self.get_opening_hours(begin.date(), end.date())
-        days = opening_hours.get(begin.date(), None)
-        if days is None or not any(day['opens'] and begin >= day['opens'] and end <= day['closes'] for day in days):
-            if not self._has_perm(user, 'can_ignore_opening_hours'):
-                raise ValidationError(_("You must start and end the reservation during opening hours"))
+        if not self.can_ignore_opening_hours(user):
+            opening_hours = self.get_opening_hours(begin.date(), end.date())
+            days = opening_hours.get(begin.date(), None)
+            if days is None or not any(day['opens'] and begin >= day['opens'] and end <= day['closes'] for day in days):
+                if not self._has_perm(user, 'can_ignore_opening_hours'):
+                    raise ValidationError(_("You must start and end the reservation during opening hours"))
 
         if self.max_period and (end - begin) > self.max_period:
             raise ValidationError(_("The maximum reservation length is %(max_period)s") %
@@ -559,21 +560,33 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
         return users
 
     def can_make_reservations(self, user):
+        if self.is_manager(user):
+            return True
         return self.reservable or self._has_perm(user, 'can_make_reservations')
 
     def can_modify_reservations(self, user):
+        if self.is_manager(user):
+            return True
         return self._has_perm(user, 'can_modify_reservations')
 
     def can_ignore_opening_hours(self, user):
+        if self.is_manager(user):
+            return True
         return self._has_perm(user, 'can_ignore_opening_hours')
 
     def can_view_reservation_extra_fields(self, user):
+        if self.is_manager(user):
+            return True
         return self._has_perm(user, 'can_view_reservation_extra_fields')
 
     def can_access_reservation_comments(self, user):
+        if self.is_manager(user):
+            return True
         return self._has_perm(user, 'can_access_reservation_comments')
 
     def can_view_catering_orders(self, user):
+        if self.is_manager(user):
+            return True
         return self._has_perm(user, 'can_view_reservation_catering_orders')
 
     def can_modify_catering_orders(self, user):
@@ -589,6 +602,8 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
         return self._has_perm(user, 'can_approve_reservation', allow_admin=False)
 
     def can_view_access_codes(self, user):
+        if self.is_manager(user):
+            return True
         return self._has_perm(user, 'can_view_reservation_access_code')
 
     def is_access_code_enabled(self):

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -303,8 +303,7 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
             opening_hours = self.get_opening_hours(begin.date(), end.date())
             days = opening_hours.get(begin.date(), None)
             if days is None or not any(day['opens'] and begin >= day['opens'] and end <= day['closes'] for day in days):
-                if not self._has_perm(user, 'can_ignore_opening_hours'):
-                    raise ValidationError(_("You must start and end the reservation during opening hours"))
+                raise ValidationError(_("You must start and end the reservation during opening hours"))
 
         if self.max_period and (end - begin) > self.max_period:
             raise ValidationError(_("The maximum reservation length is %(max_period)s") %

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -2174,6 +2174,5 @@ def test_manager_can_view_reservation_catering_orders(api_client, reservation, u
     api_client.force_authenticate(user=unit_manager_user)
 
     response = api_client.get(detail_url)
-    # import pdb; pdb.set_trace()
     assert response.status_code == 200
     assert response.data['has_catering_order'] == True

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -2065,3 +2065,115 @@ def test_reservation_cannot_add_bogus_type(resource_in_unit, reservation_data, a
     reservation_data['type'] = 'foobar'
     response = api_client.post(list_url, data=reservation_data)
     assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_manager_can_make_reservations(
+    resource_in_unit,
+    resource_in_unit2,
+    api_client, unit_manager_user,
+    reservation_data,
+    list_url
+):
+    # unit_manager_user is manager of resource_in_unit
+    resource_in_unit.reservable = False
+    resource_in_unit.save()
+    api_client.force_authenticate(user=unit_manager_user)
+    response = api_client.post(list_url, data=reservation_data)
+    assert response.status_code == 201
+
+    # unit_manager_user is NOT manager of resource_in_unit2
+    resource_in_unit2.reservable = False
+    resource_in_unit2.save()
+    reservation_data['resource'] = resource_in_unit2.pk
+    response = api_client.post(list_url, data=reservation_data)
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_manager_can_modify_reservations(resource_in_unit, resource_in_unit2, api_client, unit_manager_user, reservation_data, list_url, detail_url):
+    # unit_manager_user is manager of resource_in_unit (resource of reservation_data)
+    api_client.force_authenticate(user=unit_manager_user)
+    response = api_client.put(detail_url, data=reservation_data)
+    assert response.status_code == 200
+
+    # unit_manager_user is NOT manager of resource_in_unit2
+    reservation_data['resource'] = resource_in_unit2.pk
+    response = api_client.put(detail_url, data=reservation_data)
+    assert response.status_code == 400
+
+
+@freeze_time('2115-04-02')
+@pytest.mark.django_db
+def test_manager_can_ignore_opening_hours(api_client, list_url, reservation_data, unit_manager_user, user):
+    # regular user should not be aple to ignore opening hours
+    api_client.force_authenticate(user=user)
+    reservation_data['begin'] = '2115-04-04T06:00:00+02:00'
+    reservation_data['end'] = '2115-04-04T08:00:00+02:00'
+    response = api_client.post(list_url, data=reservation_data, HTTP_ACCEPT_LANGUAGE='en')
+    assert response.status_code == 400
+
+    api_client.force_authenticate(user=unit_manager_user)
+    reservation_data['begin'] = '2115-04-04T06:00:00+02:00'
+    reservation_data['end'] = '2115-04-04T08:00:00+02:00'
+    response = api_client.post(list_url, data=reservation_data, HTTP_ACCEPT_LANGUAGE='en')
+    assert response.status_code == 201
+
+
+@pytest.mark.django_db
+def test_manager_can_view_reservation_access_code(api_client, resource_in_unit, reservation, unit_manager_user):
+    resource_in_unit.access_code_type = Resource.ACCESS_CODE_TYPE_PIN6
+    resource_in_unit.save()
+    reservation.access_code = '123456'
+    reservation.save()
+    detail_url = reverse('reservation-detail', kwargs={'pk': reservation.pk})
+
+    api_client.force_authenticate(user=unit_manager_user)
+    response = api_client.get(detail_url)
+    assert response.status_code == 200
+    assert response.data['access_code'] == '123456'
+
+
+@pytest.mark.django_db
+def test_manager_can_view_reservation_extra_fields(api_client, resource_in_unit, reservation, unit_manager_user):
+    resource_in_unit.reservation_metadata_set = ReservationMetadataSet.objects.get(name='default')
+    resource_in_unit.save()
+    detail_url = reverse('reservation-detail', kwargs={'pk': reservation.pk})
+    api_client.force_authenticate(user=unit_manager_user)
+
+    response = api_client.get(detail_url)
+    assert response.status_code == 200
+    for field_name in DEFAULT_RESERVATION_EXTRA_FIELDS:
+        assert (field_name in response.data) is True
+
+
+@pytest.mark.django_db
+def test_manager_can_access_reservation_comments(api_client, resource_in_unit, reservation, unit_manager_user):
+    reservation.comments = 'To be a foo or not to be a foo, that is the question'
+    reservation.save()
+    detail_url = reverse('reservation-detail', kwargs={'pk': reservation.pk})
+    api_client.force_authenticate(user=unit_manager_user)
+
+    response = api_client.get(detail_url)
+    assert response.status_code == 200
+    assert response.data['comments'] == 'To be a foo or not to be a foo, that is the question'
+
+
+@pytest.mark.django_db
+def test_manager_can_view_reservation_catering_orders(api_client, reservation, unit_manager_user):
+    provider = CateringProvider.objects.create(
+        name='Ihan Hyva Catering Oy',
+        price_list_url_fi='www.ihanhyva.foobar/hinnasto/',
+    )
+    CateringOrder.objects.create(
+        reservation=reservation,
+        provider=provider
+    )
+
+    detail_url = reverse('reservation-detail', kwargs={'pk': reservation.pk})
+    api_client.force_authenticate(user=unit_manager_user)
+
+    response = api_client.get(detail_url)
+    # import pdb; pdb.set_trace()
+    assert response.status_code == 200
+    assert response.data['has_catering_order'] == True

--- a/respa_admin/tests/test_unit_view.py
+++ b/respa_admin/tests/test_unit_view.py
@@ -1,10 +1,11 @@
 import pytest
-
+from django.utils.translation import activate
 from ..views.units import UnitEditView, UnitListView
 
 
 @pytest.mark.django_db
 def test_unit_list(test_unit, test_unit2, general_admin, rf):
+    activate('en')
     test_unit2.data_source = 'external_source'
     test_unit2.save()
     request = rf.get('/')


### PR DESCRIPTION
Closes https://helsinkisolutionoffice.atlassian.net/browse/RESPA-185

Add the following permission for unit managers (with tests):

- can_make_reservations
- can_modify_reservations
- can_ignore_opening_hours
- can_view_reservation_access_code
- can_view_reservation_extra_fields
- can_access_reservation_comments
- can_view_reservation_catering_orders