### PR TITLE
Disable login for inactive users

### DIFF
--- a/resources/authentication.py
+++ b/resources/authentication.py
@@ -1,0 +1,18 @@
+from django.utils.translation import ugettext as _
+from rest_framework import exceptions
+from rest_framework_jwt.settings import api_settings
+
+from helusers.jwt import JWTAuthentication
+
+jwt_get_username_from_payload = api_settings.JWT_PAYLOAD_GET_USERNAME_HANDLER
+
+
+class RespaJWTAuthentication(JWTAuthentication):
+    def authenticate_credentials(self, payload):
+        user = super().authenticate_credentials(payload)
+
+        if user and not user.is_active:
+            msg = _('User account is disabled.')
+            raise exceptions.AuthenticationFailed(msg)
+
+        return user

--- a/resources/authentication.py
+++ b/resources/authentication.py
@@ -1,10 +1,7 @@
 from django.utils.translation import ugettext as _
 from rest_framework import exceptions
-from rest_framework_jwt.settings import api_settings
 
 from helusers.jwt import JWTAuthentication
-
-jwt_get_username_from_payload = api_settings.JWT_PAYLOAD_GET_USERNAME_HANDLER
 
 
 class RespaJWTAuthentication(JWTAuthentication):

--- a/resources/tests/test_api.py
+++ b/resources/tests/test_api.py
@@ -32,7 +32,7 @@ class JWTMixin(object):
         "exp": 1446421460
     }
 
-    def authenticated_post(self, url, data, **extra):
+    def get_auth(self, **extra):
         secret_key = generate_random_string(100)
         api_settings.JWT_SECRET_KEY = secret_key
         audience = generate_random_string(40)
@@ -53,6 +53,11 @@ class JWTMixin(object):
 
         encoded_token = jwt.encode(jwt_token, secret_key, algorithm='HS256')
         auth = 'JWT %s' % encoded_token.decode('utf8')
+
+        return auth
+
+    def authenticated_post(self, url, data, **extra):
+        auth = self.get_auth(**extra)
         response = self.client.post(url, data, HTTP_AUTHORIZATION=auth, **extra)
         return response
 

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -276,7 +276,7 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        'helusers.jwt.JWTAuthentication',
+        'resources.authentication.RespaJWTAuthentication',
     ] + ([
         "rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.BasicAuthentication",


### PR DESCRIPTION
For some reason helusers overrides DRF’s `authenticate_credentials` method without calling `super()`, thus bypassing the check for inactive users. More information in the Jira issue.

1. Create a new authentication class that inherits heluser's authentication and applies `is_active` check as it is in DRF by default.

2. Add tests

3. Slight refactoring of `JWTMixin` to make it reusable in other tests that require JWT auth.