### PR TITLE
RESPA-228 | Remove extra border width definition from textarea

### DIFF
--- a/respa_admin/static_src/styles/form/form-utils.scss
+++ b/respa_admin/static_src/styles/form/form-utils.scss
@@ -108,10 +108,6 @@ $input-height-default: 50px;
       }
     }
   }
-
-  textarea {
-    border-top-width: 1px;
-  }
 }
 
 // styling for checkbox


### PR DESCRIPTION
Remove extra border width definition from text area to avoid it "jumping" when focused. Top border width of the element was 1px, but focusing it would make it 2px. By default all borders of text elements are 2px in respa, so I removed the extra definition.