### PR TITLE
 RESPA-214 | Added instructions to documentation for usage of multiple include params

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -734,6 +734,7 @@ paths:
       - name: include
         in: query
         description: Include extra data to queryset. Currently accepts values `resource_detail` and `order_detail` (available only when the payment support is enabled).
+          To get more than one extra data entry, use multiple include parameters eg. `?include=resource_detail&include=order_detail`.
         schema:
           type: string
         example: resource_detail


### PR DESCRIPTION
Added instructions to Open API documentation for usage of multiple extra data fields with include parameter. 