### PR TITLE
RESPA-230 | Remove pytest warnings

### DIFF
--- a/respa_admin/templates/respa_admin/_base.html
+++ b/respa_admin/templates/respa_admin/_base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 {% get_available_languages as LANGUAGES %}
 {% get_current_language as LANGUAGE_CODE %}

--- a/respa_admin/templates/respa_admin/page_resources.html
+++ b/respa_admin/templates/respa_admin/page_resources.html
@@ -1,5 +1,5 @@
 {% extends "respa_admin/_base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 
 {% block koro_shape %}

--- a/respa_admin/templates/respa_admin/page_units.html
+++ b/respa_admin/templates/respa_admin/page_units.html
@@ -1,5 +1,5 @@
 {% extends "respa_admin/_base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 
 {% block koro_shape %}

--- a/respa_admin/templates/respa_admin/resources/create_resource.html
+++ b/respa_admin/templates/respa_admin/resources/create_resource.html
@@ -1,5 +1,5 @@
 {% extends "respa_admin/_base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block form_nav %}
     {% include "respa_admin/resources/form/_nav.html" %}

--- a/respa_admin/templates/respa_admin/resources/edit_user.html
+++ b/respa_admin/templates/respa_admin/resources/edit_user.html
@@ -1,5 +1,5 @@
 {% extends "respa_admin/_base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 
 {% block body %}

--- a/respa_admin/templates/respa_admin/resources/form/_user_info.html
+++ b/respa_admin/templates/respa_admin/resources/form/_user_info.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 <div id="general-info">
     <div>

--- a/respa_admin/templates/respa_admin/units/create_unit.html
+++ b/respa_admin/templates/respa_admin/units/create_unit.html
@@ -1,5 +1,5 @@
 {% extends "respa_admin/_base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block form_nav %}
     {% include "respa_admin/units/form/_nav.html" %}

--- a/respa_admin/templates/respa_admin/user_management.html
+++ b/respa_admin/templates/respa_admin/user_management.html
@@ -1,5 +1,5 @@
 {% extends "respa_admin/_base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 
 {% block koro_shape %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,11 @@ flake8-ignore =
     notifications/tests/*.py ALL
     payments/tests/*.py ALL
 addopts = --cov resources --cov reports --cov caterings --cov comments --cov notifications  --cov payments
+filterwarnings =
+    # Filter out warnings caused by naive datetimes in default values of migrations of munigeo library
+    # https://github.com/City-of-Helsinki/django-munigeo/blob/312d82b8ce/munigeo/migrations/0001_squashed_0004_building.py#L124
+    ignore:DateTimeField Address\.modified_at received a naive datetime \(1970-01-01 02.*\) while time zone support is active:RuntimeWarning
+    ignore:DateTimeField Street\.modified_at received a naive datetime \(1970-01-01 02.*\) while time zone support is active:RuntimeWarning
 
 [isort]
 atomic=true


### PR DESCRIPTION
- Replace soon to be deprecated `{% load staticfiles %}` with `{% load static %}` in templates 
- Create a pytest filter to ignore warnings caused by naive datetime default values in migrations of munigeo