### PR TITLE
Change order of installed apps

### DIFF
--- a/respa/settings.py
+++ b/respa/settings.py
@@ -101,9 +101,9 @@ SITE_ID = 1
 INSTALLED_APPS = [
     'helusers',
     'modeltranslation',
+    'grappelli',
     'helusers.apps.HelusersAdminConfig',
     'parler',
-    'grappelli',
     'django.forms',
     'django.contrib.sites',
     'django.contrib.auth',


### PR DESCRIPTION
Grappelli wasn't used due to it being introduced after `'helusers.apps.HelusersAdminConfig'` in `INSTALLED_APPS`. Changing the order fixes the issue.