### PR TITLE
RESPA-232 | Add support for changes required by Reservation screen UI

### DIFF
--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -18,7 +18,7 @@ from django.contrib.auth import get_user_model
 
 from resources.pagination import PurposePagination
 from rest_framework import exceptions, filters, mixins, serializers, viewsets, response, status
-from rest_framework.authentication import SessionAuthentication
+from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.decorators import action
 from guardian.core import ObjectPermissionChecker
 
@@ -770,6 +770,9 @@ class ResourceListViewSet(munigeo_api.GeoModelAPIView, mixins.ListModelMixin,
 class ResourceViewSet(munigeo_api.GeoModelAPIView, mixins.RetrieveModelMixin,
                       viewsets.GenericViewSet, ResourceCacheMixin):
     queryset = ResourceListViewSet.queryset
+    authentication_classes = (
+        list(drf_settings.DEFAULT_AUTHENTICATION_CLASSES) +
+        [TokenAuthentication, SessionAuthentication])
 
     def get_serializer_class(self):
         if settings.RESPA_PAYMENTS_ENABLED:


### PR DESCRIPTION
Enabled Django Rest Frameworks token authentication for single resource endpoint. This will reveal reservation extra fields to Reservation screen UI. Also enabled session authentication as it is enabled in various other endpoints and it being disabled caused some confusion when using API browser page (https://api.hel.fi/respa/v1/).