### PR TITLE
RESPA-231 | Various permission fixes and improvements

### DIFF
--- a/caterings/api.py
+++ b/caterings/api.py
@@ -150,7 +150,7 @@ class CateringOrderSerializer(serializers.ModelSerializer):
         if reservation:
             resource = reservation.resource
             user = self.context['request'].user
-            if reservation.user != user and not resource.can_modify_catering_orders(user):
+            if reservation.user != user and not resource.can_modify_reservation_catering_orders(user):
                 raise exceptions.PermissionDenied(_("No permission to modify this reservation's catering orders."))
 
         provider = validated_data['order_lines'][0]['product'].category.provider

--- a/comments/models.py
+++ b/comments/models.py
@@ -99,7 +99,7 @@ class Comment(models.Model):
         elif target_model == CateringOrder:
             if user == target_object.reservation.user:
                 return True
-            if target_object.reservation.resource.can_view_catering_orders(user):
+            if target_object.reservation.resource.can_view_reservation_catering_orders(user):
                 return True
         return False
 

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -7,7 +7,7 @@ Roles
 The following roles are defined for the users of Respa.
 
 - Super User
-- General Administrator (the old staff) (DEPRECATED)
+- General Administrator
 - Unit Group Administrator
 - Unit Administrator
 - Unit Manager
@@ -51,7 +51,11 @@ Here is an example that should help understanding the user roles.
 
    * updates the details of the Resources in the Unit.
 
-5. User with the permission granted in step 3 (in Varaamo)
+5. Unit Viewer
+
+   * examines and modifies end users reservations on request
+
+6. User with the permission granted in step 3 (in Varaamo)
 
    * approves reservations.
 
@@ -95,14 +99,44 @@ group on two scopes:
     resource group.
   * Unit: The permission is granted to all resources of the unit.
 
-In addition **General Administrators, Unit Group Administrator and Unit
-Administrators implicitly have all other resource permissions except
-``can_approve_reservation``, ``can_view_reservation_product_orders`` and
-``can_modify_paid_reservations`` for the resources in the Unit Group or
-Unit**.
+The explicit resource permissions are implemented with Django Guardian.
+All resource permissions are defined in ``resources/models/permissions.py``.
 
-The resource permissions are implemented as Django Object Permissions
-and are defined in ``resources/models/permissions.py``.  They are:
+
+In addition following user roles has resource permissions in Respa:
+
+  * General Administrators (GA)
+  * Unit Group Administrator (UGA)
+  * Unit Administrators (UA)
+  * Unit Manager (UM)
+  * Unit Viewer (UV)
+
+These roles implicitly has certain permissions for the resources in
+the Unit Group or Unit. All role based permissions are represented in
+table below.
+
+
+====================================== ====== ======= ====== ====== ======
+**Permission**                         **GA** **UGA** **UA** **UM** **UV**
+-------------------------------------- ------ ------- ------ ------ ------
+can_approve_reservation
+can_make_reservations                    X       X      X      X
+can_modify_reservations                  X       X      X      X      X
+can_ignore_opening_hours                 X       X      X      X
+can_view_reservation_access_code         X       X      X      X      X
+can_view_reservation_extra_fields        X       X      X      X      X
+can_view_reservation_user                X       X      X             X
+can_access_reservation_comments          X       X      X      X      X
+can_comment_reservations                 X       X      X             X
+can_view_reservation_catering_orders     X       X      X      X
+can_modify_reservation_catering_orders
+can_view_reservation_product_orders
+can_modify_paid_reservations
+can_bypass_payment                       X       X      X      X
+====================================== ====== ======= ====== ====== ======
+
+
+Definitions of the permissions:
 
 can_approve_reservation
   Can approve reservations
@@ -122,11 +156,14 @@ can_view_reservation_access_code
 can_view_reservation_extra_fields
   Can view reservation extra fields
 
-can_bypass_payment
-  Can bypass payment when making a reservation
+can_view_reservation_user
+  Can view reservation user
 
 can_access_reservation_comments
   Can access reservation comments
+
+can_comment_reservations
+  Can create comments for a reservation
 
 can_view_reservation_catering_orders
   Can view reservation catering orders
@@ -139,6 +176,9 @@ can_view_reservation_product_orders
 
 can_modify_paid_reservations
   Can modify paid reservations
+
+can_bypass_payment
+  Can bypass payment when making a reservation
 
 Respa Admin Permissions
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -157,24 +197,14 @@ their permissions are unscoped.
 **Permission**                         **Scope**    **GA** **UGA** **UA** **UM** **UV**
 -------------------------------------- ------------ ------ ------- ------ ------ ------
 can_login_to_respa_admin               General        X       X      X      X
-can_modify_resources                   Unit           X       X      X      X
-can_modify_unit                        Unit           X       X      X      X
-can_bypass_payment                     Unit           X       X      X      X
 can_access_permissions_view            General        X       X      X
 can_search_users                       General        X       X      X
+can_modify_resource                    Unit           X       X      X      X
 can_manage_resource_perms              Unit           X       X      X
+can_modify_unit                        Unit           X       X      X      X
 can_manage_auth_of_unit                Unit           X       X      X
 can_create_resource_to_unit            Unit           X       X      X
 can_delete_resource_of_unit            Unit           X       X      X
-can_make_reservations                  Unit                                 X
-can_modify_reservations                Unit                                 X      X
-can_ignore_opening_hours               Unit                                 X
-can_view_reservation_access_code       Unit                                 X      X
-can_view_reservation_extra_fields      Unit                                 X      X
-can_view_reservation_user              Unit           X       X      X             X
-can_access_reservation_comments        Unit                                 X      X
-can_comment_reservations               Unit           X       X      X             X
-can_view_reservation_catering_orders   Unit                                 X
 can_manage_auth_of_unit_group          Unit Group     X       X
 can_create_unit_to_group               Unit Group     X       X
 can_delete_unit_of_group               Unit Group     X       X
@@ -185,21 +215,21 @@ Definitions of the permissions:
 can_login_to_respa_admin
     Can login to Respa Admin interface
 
-can_modify_resources
-    Can modify Resources of the Unit
-
-can_modify_unit
-    Can modify the Unit
-
 can_access_permissions_view
     Can access permission management view
 
 can_search_users
     Can search users (by e-mail)
 
+can_modify_resource
+    Can modify Resources of the Unit
+
 can_manage_resource_perms
     Can grant Resource Permissions to any user within scope of the
     administrated Unit
+
+can_modify_unit
+    Can modify the Unit
 
 can_manage_auth_of_unit
     Can add/remove users as Unit Administrators or Unit Managers
@@ -218,12 +248,6 @@ can_create_unit_to_group
 
 can_delete_unit_of_group
     Can delete an Unit of the Unit Group
-
-can_view_reservation_user
-    Can see user object in reservations which contains id, name and email
-
-can_comment_reservation
-    Can add comments to a reservation
 
 
 Implementation of the Roles

--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -79,7 +79,8 @@ class PurposeViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = PurposePagination
 
     def get_queryset(self):
-        if is_staff(self.request.user):
+        user = self.request.user
+        if is_staff(user) or is_general_admin(user):
             return self.queryset
         else:
             return self.queryset.filter(public=True)

--- a/resources/auth.py
+++ b/resources/auth.py
@@ -4,14 +4,17 @@ def is_authenticated_user(user):
     return bool(user and user.is_authenticated)
 
 
-def is_staff(user):
-    return is_authenticated_user(user) and (
-        user.is_staff or user.is_superuser or is_any_admin(user))
+def is_superuser(user):
+    return is_authenticated_user(user) and user.is_superuser
 
 
 def is_general_admin(user):
     return is_authenticated_user(user) and (
         user.is_superuser or getattr(user, 'is_general_admin', False))
+
+
+def is_staff(user):
+    return is_authenticated_user(user) and user.is_staff
 
 
 def is_any_admin(user):

--- a/resources/models/permissions.py
+++ b/resources/models/permissions.py
@@ -1,4 +1,7 @@
 from django.utils.translation import ugettext_lazy as _
+from ..enums import UnitAuthorizationLevel, UnitGroupAuthorizationLevel
+
+# Always update permissions.rst documentation accordingly after modifying this file!
 
 RESOURCE_PERMISSIONS = (
     ('can_approve_reservation', _('Can approve reservation')),
@@ -16,6 +19,67 @@ RESOURCE_PERMISSIONS = (
     ('can_modify_paid_reservations', _('Can modify paid reservations')),
     ('can_bypass_payment', _('Can bypass payment for paid reservations')),
 )
+
+UNIT_ROLE_PERMISSIONS = {
+    'can_approve_reservation': [],
+    'can_make_reservations': [
+        UnitGroupAuthorizationLevel.admin,
+        UnitAuthorizationLevel.admin,
+        UnitAuthorizationLevel.manager
+        ],
+    'can_modify_reservations': [
+        UnitGroupAuthorizationLevel.admin,
+        UnitAuthorizationLevel.admin,
+        UnitAuthorizationLevel.manager,
+        UnitAuthorizationLevel.viewer
+        ],
+    'can_ignore_opening_hours': [
+        UnitGroupAuthorizationLevel.admin,
+        UnitAuthorizationLevel.admin,
+        UnitAuthorizationLevel.manager
+        ],
+    'can_view_reservation_access_code': [
+        UnitGroupAuthorizationLevel.admin,
+        UnitAuthorizationLevel.admin,
+        UnitAuthorizationLevel.manager,
+        UnitAuthorizationLevel.viewer
+        ],
+    'can_view_reservation_extra_fields': [
+        UnitGroupAuthorizationLevel.admin,
+        UnitAuthorizationLevel.admin,
+        UnitAuthorizationLevel.manager,
+        UnitAuthorizationLevel.viewer
+        ],
+    'can_view_reservation_user': [
+        UnitGroupAuthorizationLevel.admin,
+        UnitAuthorizationLevel.admin,
+        UnitAuthorizationLevel.viewer
+        ],
+    'can_access_reservation_comments': [
+        UnitGroupAuthorizationLevel.admin,
+        UnitAuthorizationLevel.admin,
+        UnitAuthorizationLevel.manager,
+        UnitAuthorizationLevel.viewer
+        ],
+    'can_comment_reservations': [
+        UnitGroupAuthorizationLevel.admin,
+        UnitAuthorizationLevel.admin,
+        UnitAuthorizationLevel.viewer
+        ],
+    'can_view_reservation_catering_orders': [
+        UnitGroupAuthorizationLevel.admin,
+        UnitAuthorizationLevel.admin,
+        UnitAuthorizationLevel.manager
+        ],
+    'can_modify_reservation_catering_orders': [],
+    'can_view_reservation_product_orders': [],
+    'can_modify_paid_reservations': [],
+    'can_bypass_payment': [
+        UnitGroupAuthorizationLevel.admin,
+        UnitAuthorizationLevel.admin,
+        UnitAuthorizationLevel.manager
+        ]
+}
 
 UNIT_PERMISSIONS = [
     ('unit:' + name, description)

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -224,7 +224,7 @@ class Reservation(ModifiableModel):
     def can_view_access_code(self, user):
         if self.is_own(user):
             return True
-        return self.resource.can_view_access_codes(user)
+        return self.resource.can_view_reservation_access_code(user)
 
     def set_state(self, new_state, user):
         # Make sure it is a known state
@@ -311,7 +311,7 @@ class Reservation(ModifiableModel):
     def can_view_catering_orders(self, user):
         if self.is_own(user):
             return True
-        return self.resource.can_view_catering_orders(user)
+        return self.resource.can_view_reservation_catering_orders(user)
 
     def can_add_product_order(self, user):
         return self.is_own(user)
@@ -319,7 +319,7 @@ class Reservation(ModifiableModel):
     def can_view_product_orders(self, user):
         if self.is_own(user):
             return True
-        return self.resource.can_view_product_orders(user)
+        return self.resource.can_view_reservation_product_orders(user)
 
     def get_order(self):
         return getattr(self, 'order', None)

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -29,7 +29,7 @@ from PIL import Image
 from guardian.shortcuts import get_objects_for_user, get_users_with_perms
 from guardian.core import ObjectPermissionChecker
 
-from ..auth import is_authenticated_user, is_general_admin
+from ..auth import is_authenticated_user, is_general_admin, is_superuser
 from ..errors import InvalidImage
 from ..fields import EquipmentField
 from .accessibility import AccessibilityValue, AccessibilityViewpoint, ResourceAccessibility
@@ -38,7 +38,8 @@ from .utils import create_datetime_days_from_now, get_translated, get_translated
 from .equipment import Equipment
 from .unit import Unit
 from .availability import get_opening_hours
-from .permissions import RESOURCE_GROUP_PERMISSIONS
+from .permissions import RESOURCE_GROUP_PERMISSIONS, UNIT_ROLE_PERMISSIONS
+from ..enums import UnitAuthorizationLevel, UnitGroupAuthorizationLevel
 
 
 def generate_access_code(access_code_type):
@@ -152,7 +153,11 @@ class ResourceQuerySet(models.QuerySet):
                                      with_superuser=False)
         resource_groups = get_objects_for_user(user, 'group:%s' % perm, klass=ResourceGroup,
                                                with_superuser=False)
-        return self.filter(Q(unit__in=units) | Q(groups__in=resource_groups)).distinct()
+
+        allowed_roles = UNIT_ROLE_PERMISSIONS.get(perm)
+        units_where_role = Unit.objects.by_roles(user, allowed_roles)
+
+        return self.filter(Q(unit__in=list(units) + list(units_where_role)) | Q(groups__in=resource_groups)).distinct()
 
 
 class Resource(ModifiableModel, AutoIdentifiedModel):
@@ -531,26 +536,30 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
         :rtype: bool
         """
         if not self.unit:
-            return is_general_admin(user)
+            return False
         return self.unit.is_manager(user)
 
     def is_viewer(self, user):
         """
-        Check if the given user is a manager of this resource.
+        Check if the given user is a viewer of this resource.
 
         :type user: users.models.User
         :rtype: bool
         """
         if not self.unit:
-            return is_general_admin(user)
+            return False
         return self.unit.is_viewer(user)
 
     def _has_perm(self, user, perm, allow_admin=True):
         if not is_authenticated_user(user):
             return False
-        # Admins are almighty.
-        if self.is_admin(user) and allow_admin:
+
+        if (self.is_admin(user) and allow_admin) or user.is_superuser:
             return True
+
+        return self._has_role_perm(user, perm) or self._has_explicit_perm(user, perm, allow_admin)
+
+    def _has_explicit_perm(self, user, perm, allow_admin=True):
         if hasattr(self, '_permission_checker'):
             checker = self._permission_checker
         else:
@@ -563,6 +572,22 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
         resource_group_perms = [checker.has_perm('group:%s' % perm, rg) for rg in self.groups.all()]
         return any(resource_group_perms)
 
+    def _has_role_perm(self, user, perm):
+        allowed_roles = UNIT_ROLE_PERMISSIONS.get(perm)
+        is_allowed = False
+
+        if (UnitAuthorizationLevel.admin in allowed_roles
+            or UnitGroupAuthorizationLevel.admin in allowed_roles) and not is_allowed:
+            is_allowed = self.is_admin(user)
+
+        if UnitAuthorizationLevel.manager in allowed_roles and not is_allowed:
+            is_allowed = self.is_manager(user)
+
+        if UnitAuthorizationLevel.viewer in allowed_roles and not is_allowed:
+            is_allowed = self.is_viewer(user)
+
+        return is_allowed
+
     def get_users_with_perm(self, perm):
         users = {u for u in get_users_with_perms(self.unit) if u.has_perm('unit:%s' % perm, self.unit)}
         for rg in self.groups.all():
@@ -570,49 +595,33 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
         return users
 
     def can_make_reservations(self, user):
-        if self.is_manager(user):
-            return True
         return self.reservable or self._has_perm(user, 'can_make_reservations')
 
     def can_modify_reservations(self, user):
-        if self.is_manager(user) or self.is_viewer(user):
-            return True
         return self._has_perm(user, 'can_modify_reservations')
 
     def can_comment_reservations(self, user):
-        if self.is_admin(user) or self.is_viewer(user):
-            return True
         return self._has_perm(user, 'can_comment_reservations')
 
     def can_ignore_opening_hours(self, user):
-        if self.is_manager(user):
-            return True
         return self._has_perm(user, 'can_ignore_opening_hours')
 
     def can_view_reservation_extra_fields(self, user):
-        if self.is_manager(user) or self.is_viewer(user):
-            return True
         return self._has_perm(user, 'can_view_reservation_extra_fields')
 
     def can_view_reservation_user(self, user):
-        if self.is_admin(user) or self.is_viewer(user):
-            return True
         return self._has_perm(user, 'can_view_reservation_user')
 
     def can_access_reservation_comments(self, user):
-        if self.is_admin(user) or self.is_manager(user) or self.is_viewer(user):
-            return True
         return self._has_perm(user, 'can_access_reservation_comments')
 
-    def can_view_catering_orders(self, user):
-        if self.is_manager(user):
-            return True
+    def can_view_reservation_catering_orders(self, user):
         return self._has_perm(user, 'can_view_reservation_catering_orders')
 
-    def can_modify_catering_orders(self, user):
+    def can_modify_reservation_catering_orders(self, user):
         return self._has_perm(user, 'can_modify_reservation_catering_orders')
 
-    def can_view_product_orders(self, user):
+    def can_view_reservation_product_orders(self, user):
         return self._has_perm(user, 'can_view_reservation_product_orders', allow_admin=False)
 
     def can_modify_paid_reservations(self, user):
@@ -621,14 +630,10 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
     def can_approve_reservations(self, user):
         return self._has_perm(user, 'can_approve_reservation', allow_admin=False)
 
-    def can_view_access_codes(self, user):
-        if self.is_manager(user) or self.is_viewer(user):
-            return True
+    def can_view_reservation_access_code(self, user):
         return self._has_perm(user, 'can_view_reservation_access_code')
 
     def can_bypass_payment(self, user):
-        if self.is_manager(user) or self.is_admin(user):
-            return True
         return self._has_perm(user, 'can_bypass_payment')
 
     def is_access_code_enabled(self):

--- a/resources/tests/test_resource_api.py
+++ b/resources/tests/test_resource_api.py
@@ -80,7 +80,7 @@ def test_user_permissions_in_resource_endpoint(api_client, resource_in_unit, use
     user.is_general_admin = True
     user.save()
     api_client.force_authenticate(user=user)
-    _check_permissions_dict(api_client, resource_in_unit, is_admin=True, is_manager=True,
+    _check_permissions_dict(api_client, resource_in_unit, is_admin=True, is_manager=False,
                             is_viewer=False, can_make_reservations=True, can_ignore_opening_hours=True,
                             can_bypass_payment=True)
     user.is_general_admin = False
@@ -127,7 +127,7 @@ def test_user_permissions_in_resource_endpoint(api_client, resource_in_unit, use
     )
     user.save()
     api_client.force_authenticate(user=user)
-    _check_permissions_dict(api_client, resource_in_unit, is_admin=True, is_manager=True,
+    _check_permissions_dict(api_client, resource_in_unit, is_admin=True, is_manager=False,
                             is_viewer=False, can_make_reservations=True,can_ignore_opening_hours=True,
                             can_bypass_payment=True)
     user.unit_authorizations.all().delete()

--- a/respa_admin/permissions.py
+++ b/respa_admin/permissions.py
@@ -1,11 +1,11 @@
-from resources.auth import is_any_admin, is_staff
+from resources.auth import is_any_admin, is_staff, is_general_admin
 
 ########################################################################
 # General permissions
 
 
 def can_login_to_respa_admin(user):
-    return is_staff(user)
+    return is_staff(user) or is_general_admin(user)
 
 
 def can_access_permissions_view(user):
@@ -21,7 +21,7 @@ def can_search_users(user):
 
 
 def can_modify_resource(user, resource):
-    return resource.unit.is_manager(user)
+    return resource.unit.is_admin(user) or resource.unit.is_manager(user)
 
 
 def can_manage_resource_perms(user, resource):
@@ -33,7 +33,7 @@ def can_manage_resource_perms(user, resource):
 
 
 def can_modify_unit(user, unit):
-    return unit.is_manager(user)
+    return unit.is_admin(user) or unit.is_manager(user)
 
 
 def can_manage_auth_of_unit(user, unit):


### PR DESCRIPTION
### Resource permissions

- Queryset filtering by permissions (**with_perm**-method of resource queryset) are now aware of new roles (Unit Group Admin, Unit Admin, Unit Manager, Unit Viewer). Also wrote unit tests for **with_perm**-method.
- Permissions of each role are now defined in **permissions.py** in **UNIT_ROLE_PERMISSIONS** variable so they can be accessed from a single location in code. This makes reading and modifying role permissions much easier.
![image](https://user-images.githubusercontent.com/56429082/73438108-22e67b00-4356-11ea-8429-86105bcc04d8.png)


- Refactored method structure of resource models permissions to increase readability. Also renamed a couple of **can_*** - methods to be exactly same name as corresponding permission for consistency as most of the methods already were.

 1. **can_*** - methods now always calls only **_has_perm** method
 2. **_has_perm** method now calls **_has_role_permission** and **_has_explicit_permission**
 3. **_has_role_permission** checks if user has role that implicitly allows them to have certain permission. Uses before mentoined **UNIT_ROLE_PERMISSIONS** variable from **permissions.py**
 4. **_has_explicit_permission** checks if user has explicit Django Guardian permission to the resource

- **is_admin**, **is_manager** and **is_viewer** now returns true only when user truly has that role. Is_manager used to return true even if user only had admin role.

### Permissions.rst documentation

- Removed resource permissions from **Respa Admin Permissions** section and created another similar table to represent role permissions under **Resource Permissions** section. 
![image](https://user-images.githubusercontent.com/56429082/73438380-9ee0c300-4356-11ea-8c90-f5a5eaf532b2.png)

- Various minor fixes to documentation where unclear or inconsistent with implementation


### This PR also solves RESPA-109