### PR TITLE
Kulkunen SiPass driver changes

### DIFF
--- a/kulkunen/drivers/sipass.py
+++ b/kulkunen/drivers/sipass.py
@@ -535,7 +535,7 @@ class SiPassDriver(AccessControlDriver):
                     'MobileServiceProviderId': '0',
                     'PagerNumber': '',
                     'PagerServiceProviderId': '0',
-                    'PhoneNumber': ''
+                    'PhoneNumber': '',
                     'ManagerEmailAddress': ''
                 },
                 'DateOfBirth': '',

--- a/kulkunen/drivers/sipass.py
+++ b/kulkunen/drivers/sipass.py
@@ -536,6 +536,7 @@ class SiPassDriver(AccessControlDriver):
                     'PagerNumber': '',
                     'PagerServiceProviderId': '0',
                     'PhoneNumber': ''
+                    'ManagerEmailAddress': ''
                 },
                 'DateOfBirth': '',
                 'PayrollNumber': '',
@@ -551,7 +552,7 @@ class SiPassDriver(AccessControlDriver):
             'SmartCardProfileId': '0',
             'SmartCardProfileName': None,
             'StartDate': start_time.isoformat(),
-            'Status': 61,  # 61 means Valid
+            'Status': 62,  # 62 means Valid
             'Token': '-1',
             'TraceDetails': {
                 'CardLastUsed': None,


### PR DESCRIPTION
Recent changes in the SiPass API broke Kulkunen. Added the `ManagerEmailAddress` attribute and changed the `Status` value to 62 to fix this as per instructions from Kuva SiPass expert.