### PR TITLE
RESPA-235 | Use raw_id_field on Token model's user

### DIFF
--- a/resources/admin/__init__.py
+++ b/resources/admin/__init__.py
@@ -28,6 +28,7 @@ from ..models import (
     ResourceEquipment, ResourceGroup, ResourceImage, ResourceType, TermsOfUse,
     Unit, UnitAuthorization, UnitIdentifier, UnitGroup, UnitGroupAuthorization)
 from munigeo.models import Municipality
+from rest_framework.authtoken.admin import Token
 
 logger = logging.getLogger(__name__)
 
@@ -364,6 +365,15 @@ class ReservationMetadataFieldAdmin(admin.ModelAdmin):
         return super().formfield_for_dbfield(db_field, **kwargs)
 
 
+# Override TokenAdmin of django rest framework
+# to use raw_id_field on user
+class RespaTokenAdmin(admin.ModelAdmin):
+    list_display = ('key', 'user', 'created')
+    fields = ('user',)
+    ordering = ('-created',)
+    raw_id_fields = ('user',)
+
+
 admin_site.register(ResourceImage, ResourceImageAdmin)
 admin_site.register(Resource, ResourceAdmin)
 admin_site.register(Reservation, ReservationAdmin)
@@ -384,3 +394,7 @@ admin.site.register(Municipality, MunicipalityAdmin)
 admin.site.register(AccessibilityViewpoint, AccessibilityViewpointAdmin)
 admin.site.register(AccessibilityValue)
 admin.site.register(ResourceAccessibility, ResourceAccessibilityAdmin)
+
+if admin.site.is_registered(Token):
+    admin.site.unregister(Token)
+admin_site.register(Token, RespaTokenAdmin)


### PR DESCRIPTION
Override DRF's `TokenAdmin` to treat User-relation as `raw_id_field`