### PR TITLE
Fix admin bypassing time restrictions

### DIFF
--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -226,7 +226,7 @@ class ReservationSerializer(ExtraDataMixin, TranslatedModelSerializer, munigeo_a
         # Run model clean
         instance = Reservation(**data)
         try:
-            instance.clean(original_reservation=reservation)
+            instance.clean(original_reservation=reservation, user=request_user)
         except DjangoValidationError as exc:
 
             # Convert Django ValidationError to DRF ValidationError so that in the response

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -346,9 +346,10 @@ class Reservation(ModifiableModel):
         that it can be excluded when checking if the resource is available.
         """
 
-        user = self.user
-        if not user and 'user' in kwargs:
+        if 'user' in kwargs:
             user = kwargs['user']
+        else:
+            user = self.user
 
         user_is_admin = user and self.resource.is_admin(user)
 

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -2257,3 +2257,38 @@ def test_query_counts(user_api_client, staff_api_client, list_url, django_assert
 
     with django_assert_max_num_queries(MAX_QUERIES):
         staff_api_client.get(list_url)
+
+
+@pytest.mark.django_db
+def test_admin_may_bypass_min_period(resource_in_unit, user, user_api_client, list_url):
+    # min_period is bypassed respecting slot_size restriction
+    resource_in_unit.min_period = datetime.timedelta(hours=1)
+    resource_in_unit.slot_size = datetime.timedelta(minutes=30)
+    resource_in_unit.save()
+
+    UnitAuthorization.objects.create(
+        subject=resource_in_unit.unit,
+        level=UnitAuthorizationLevel.admin,
+        authorized=user,
+    )
+
+    tz = timezone.get_current_timezone()
+    begin = tz.localize(datetime.datetime(2115, 6, 1, 8, 0, 0))
+    end = begin + datetime.timedelta(hours=0, minutes=30)
+
+    reservation_data = {
+        'resource': resource_in_unit.pk,
+        'begin': begin,
+        'end': end,
+    }
+
+    response = user_api_client.post(list_url, reservation_data)
+    assert response.status_code == 201
+    Reservation.objects.all().delete()
+
+    # min_period is bypassed and slot_size restriction is violated
+    resource_in_unit.slot_size = datetime.timedelta(minutes=25)
+    resource_in_unit.save()
+
+    response = user_api_client.post(list_url, reservation_data)
+    assert response.status_code == 400


### PR DESCRIPTION
When calling model's `clean()` method through serializer, admin was undefined and therefore every user would be treated as non-admin.