### PR TITLE
RESPA-233 | Add extra checks to removing user permissions in JS

### DIFF
--- a/respa_admin/static_src/js/userForm.js
+++ b/respa_admin/static_src/js/userForm.js
@@ -34,8 +34,15 @@ function addNewPermission() {
 }
 
 function removePermission() {
-  $(this).next('span.hidden-delete-checkbox').find('input').prop("checked", true);
-  $(this).closest('.permission-item').hide()
+  let permissionValue = $(this).closest('.permission-item').find('[type="hidden"]').first().val();
+  if(permissionValue) {
+    $(this).next('span.hidden-delete-checkbox').find('input').prop("checked", true);
+    $(this).closest('.permission-item').hide();
+  }
+  else {
+    $(this).closest('.permission-item').remove();
+  }
+  initializeUserForm();
 }
 
 function initializeUserForm() {


### PR DESCRIPTION
When deleting permissions in UI, permissions that are not yet saved in database are just removed from DOM completely (instead of checking "to-be-deleted" checkbox). 