### PR TITLE
Fixed user anonymization errors

### DIFF
--- a/resources/tests/test_admin_actions.py
+++ b/resources/tests/test_admin_actions.py
@@ -3,6 +3,7 @@ import pytest
 from django.contrib.auth import get_user_model
 
 from resources.models import Reservation
+from allauth.socialaccount.models import SocialAccount, EmailAddress
 from users.admin import anonymize_user_data
 
 
@@ -14,7 +15,12 @@ def test_anonymize_user_data(api_client, resource_in_unit, user):
     user.first_name = 'testi_ukkeli'
     user.save()
     original_uuid = user.uuid
+    original_email = user.email
     user_pk = user.pk
+
+    SocialAccount.objects.create(user=user, uid=original_uuid, provider='helsinki')
+    EmailAddress.objects.create(user=user, email=original_email)
+
     Reservation.objects.create(
         resource=resource_in_unit,
         begin='2015-04-04T09:00:00+02:00',
@@ -32,3 +38,5 @@ def test_anonymize_user_data(api_client, resource_in_unit, user):
     assert reservation.event_description == 'Sensitive data of this reservation has been anonymized by a script.'
     changed_user = get_user_model().objects.get(pk=user_pk)
     assert changed_user.uuid != original_uuid
+    assert not SocialAccount.objects.filter(user=user, uid=original_uuid).exists()
+    assert not EmailAddress.objects.filter(user=user, email=original_email).exists()

--- a/users/admin.py
+++ b/users/admin.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.contrib import admin
 from resources.models import Reservation
+from allauth.socialaccount.models import SocialAccount, EmailAddress
 
 
 User = get_user_model()
@@ -77,6 +78,9 @@ def anonymize_user_data(modeladmin, request, queryset):
         user.email = f'{user.first_name}.{user.last_name}@anonymized.net'.lower()
         user.uuid = uuid.uuid4()
         user.save()
+
+        SocialAccount.objects.filter(user=user).update(uid=user.uuid, extra_data='{}')
+        EmailAddress.objects.filter(user=user).update(email=user.email)
 
         user_reservations = Reservation.objects.filter(user=user)
         user_reservations.update(


### PR DESCRIPTION
Fixed bug where anonymizing users didn't anonymize data in related **SocialAccount** and **EmailAddress** models causing errors.

Errors were caused because **SocialAccount** still has original UUID and **EmailAddress** still had original email after anonymization. These objects were then used when user tried to "register" again with their social account and data between newly created user and existing  **SocialAccount** and **EmailAddress** objects were inconsistent in assertion checks made by helusers.

Related sentry issue:
https://sentry.hel.ninja/aok/julkirespa/issues/10372/