### PR TITLE
RESPA-239 | Allow customizing respa admin theme

### DIFF
--- a/respa_admin/static_src/styles/application-variables.scss
+++ b/respa_admin/static_src/styles/application-variables.scss
@@ -1,0 +1,3 @@
+// To customize color variables copy content of application_variables.scss
+// from node_modules/hel-bootstrap-3/src/sass/application-variables and delete/comment this import
+@import "../../node_modules/hel-bootstrap-3/src/sass/application-variables";

--- a/respa_admin/static_src/styles/base.scss
+++ b/respa_admin/static_src/styles/base.scss
@@ -11,8 +11,7 @@ $brand-dark:   #009246; // $hel-tram
 
 @import "../../node_modules/hel-bootstrap-3/src/sass/helsinki-variables";
 
-// @import application-variables;
-@import "../../node_modules/hel-bootstrap-3/src/sass/application-variables";
+@import "./application-variables";
 
 @import "../../node_modules/hel-bootstrap-3/src/sass/theme-bootstrap-variables";
 

--- a/respa_admin/static_src/styles/common.scss
+++ b/respa_admin/static_src/styles/common.scss
@@ -35,7 +35,7 @@
   vertical-align: middle;
   height: $input-height-default;
   padding: $padding-large-vertical 24px;
-  background-color: $hel-copper;
+  background-color: $theme-success-light;
   border: 0;
   color: $white;
   text-decoration: none;

--- a/respa_admin/static_src/styles/form/form-utils.scss
+++ b/respa_admin/static_src/styles/form/form-utils.scss
@@ -147,8 +147,8 @@ $input-height-default: 50px;
       margin-top: -9px;
       width: 20px;
       height: 20px;
-      background: #00ed95;
-      border: #00ed95 solid 2px;
+      background: $theme-success-light;
+      border: $theme-success-light solid 2px;
     }
 
     &:not(:checked) + label:after, &:checked + label:after {
@@ -173,7 +173,7 @@ $input-height-default: 50px;
     }
 
     &:checked + label {
-      color: #00ed95;
+      color: $theme-success-light;
     }
 
     &[data-indeterminate] + label:after {
@@ -284,7 +284,7 @@ $input-height-default: 50px;
       font-size: 11px;
       width: 12px;
       height: 12px;
-      background-color: #00ed95;
+      background-color: $theme-success-light;
       -moz-border-radius: 50px;
       -webkit-border-radius: 50px;
       border-radius: 50px;
@@ -297,13 +297,13 @@ $input-height-default: 50px;
 }
 
 .rdio input[type="radio"]:checked + label {
-  color: #00ed95;
+  color: $theme-success-light;
 
   &:before {
-    border-color: #00ed95;
+    border-color: $theme-success-light;
   }
 
   &::after {
-    background-color: #00ed95;
+    background-color: $theme-success-light;
   }
 }

--- a/respa_admin/static_src/styles/form/navbar-form.scss
+++ b/respa_admin/static_src/styles/form/navbar-form.scss
@@ -85,14 +85,14 @@
           a {
 
             &:hover {
-              color: $hel-coat;
+              color: $theme-primary-dark;
               font-weight: bold;
             }
     
             &:after {
               height: 3px;
               border: 0;
-              background-color: $hel-coat;
+              background-color: $theme-primary-dark;
               bottom: 0;
             }
           }

--- a/respa_admin/static_src/styles/navbar.scss
+++ b/respa_admin/static_src/styles/navbar.scss
@@ -46,7 +46,7 @@
   }
 
   nav.service {
-    background: $hel-coat;
+    background: $theme-primary-dark;
     border: 0;
 
     a.navbar-brand {

--- a/respa_admin/static_src/styles/page-home.scss
+++ b/respa_admin/static_src/styles/page-home.scss
@@ -22,32 +22,32 @@ main {
       top: 0;
       bottom: 0;
       width: 100%;
-      background-color: $hel-fog;
+      background-color: $theme-secondary-light;
       transform: rotate(180deg);
     }
 
     &.koro-basic:before {
       background-color: transparent;
-      @include koro("basic", $hel-fog, 400);
+      @include koro("basic", $theme-secondary-light, 400);
     }
 
     &.koro-pulse:before {
       background-color: transparent;
-      @include koro("pulse", $hel-fog, 400);
+      @include koro("pulse", $theme-secondary-light, 400);
     }
 
     &.koro-beat:before {
       background-color: transparent;
-      @include koro("beat", $hel-fog, 400);
+      @include koro("beat", $theme-secondary-light, 400);
     }
     &.koro-storm:before {
       background-color: transparent;
-      @include koro("storm", $hel-fog, 400);
+      @include koro("storm", $theme-secondary-light, 400);
     }
 
     &.koro-wave:before {
       background-color: transparent;
-      @include koro("wave", $hel-fog, 400);
+      @include koro("wave", $theme-secondary-light, 400);
     }
 
     .container {

--- a/respa_admin/static_src/styles/pagination.scss
+++ b/respa_admin/static_src/styles/pagination.scss
@@ -22,7 +22,7 @@
     }
 
     .active-page {
-      background: $hel-coat;
+      background: $theme-primary-dark;
       color: $white;
     }
   }


### PR DESCRIPTION
Allow customizing respa admin theme.

`hel-bootstrap-3/src/sass/application-variables` is now imported via `application_variables.scss` that exists in this repository. Customization happens in here and no other files need to be touched.

TODO: Document this in readme.