### PR TITLE
RESPA-254 | Fix period formset in resourceview

### DIFF
--- a/respa_admin/views/base.py
+++ b/respa_admin/views/base.py
@@ -23,8 +23,11 @@ class PeriodMixin():
         such as self.object and self.model.
     """
     def get_context_data(self, **kwargs):
+        is_formset_in_kwargs = 'period_formset_with_days' in kwargs
         context = super().get_context_data(**kwargs)
-        context['period_formset_with_days'] = self.get_period_formset()
+        # If formset is passed explicitly via kwargs, do not override
+        if not is_formset_in_kwargs:
+            context['period_formset_with_days'] = self.get_period_formset()
         return context
 
     def get_period_formset(self):


### PR DESCRIPTION
Original issue had to do with resource images, but that was not the problem.

After unsuccessfully submitting resource form, Django returned a faulty formset.

This was fixed by changing `PeriodMixin` class to not override `period_formset_with_days` in case the said formset was passed explicitly via kwargs.