### PR TITLE
RESPA-268 | Send reservation emails to billing email address

### DIFF
--- a/payments/tests/test_notifications.py
+++ b/payments/tests/test_notifications.py
@@ -97,7 +97,7 @@ def test_reservation_created_notification(order_with_products):
     assert len(mail.outbox) == 1
     check_received_mail_exists(
         'Reservation created subject.',
-        order_with_products.reservation.user.email,
+        order_with_products.reservation.billing_email_address,
         get_expected_strings(order_with_products),
     )
 
@@ -124,7 +124,7 @@ def test_reservation_cancelled_notification(order_with_products, order_state, no
         assert len(mail.outbox) == 1
         check_received_mail_exists(
             'Reservation cancelled subject.',
-            order_with_products.reservation.user.email,
+            order_with_products.reservation.billing_email_address,
             get_expected_strings(order_with_products),
         )
     else:

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -480,7 +480,9 @@ class Reservation(ModifiableModel):
         except NotificationTemplate.DoesNotExist:
             return
 
-        if user:
+        if getattr(self, 'order', None) and self.billing_email_address:
+            email_address = self.billing_email_address
+        elif user:
             email_address = user.email
         else:
             if not (self.reserver_email_address or self.user):


### PR DESCRIPTION
Receipt of purchases are sent to email address customer typed in reservation form in Varaamo. However Respa reservation confirmation emails were still sent to user accounts email. This PR fixes that and all reservation emails are sent to billing_email_address if it is set and there is order related to the reservation.