### PR TITLE
Add order_number field under order object in reservation API endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1521,6 +1521,8 @@ components:
             $ref: '#/components/schemas/order_line_read'
         price:
           type: string
+        order_number:
+          type: string
     order_creation_request:
       type: object
       properties:

--- a/payments/api/base.py
+++ b/payments/api/base.py
@@ -68,4 +68,4 @@ class OrderSerializerBase(serializers.ModelSerializer):
 
     class Meta:
         model = Order
-        fields = ('state', 'order_lines', 'price')
+        fields = ('state', 'order_lines', 'price', 'order_number')

--- a/payments/tests/test_reservation_api.py
+++ b/payments/tests/test_reservation_api.py
@@ -18,7 +18,7 @@ from .test_order_api import ORDER_LINE_FIELDS, PRODUCT_FIELDS
 
 LIST_URL = reverse('reservation-list')
 
-ORDER_FIELDS = {'id', 'state', 'price', 'order_lines'}
+ORDER_FIELDS = {'id', 'state', 'price', 'order_number', 'order_lines'}
 
 
 def get_detail_url(reservation):


### PR DESCRIPTION
To get full order object with reservation, use _?include=order_detail_ GET-parameter