### PR TITLE
Use python:3.8-bullseye as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM python:3.8
+FROM python:3.8-bullseye
 
 ENV APP_NAME respa
 
@@ -9,8 +9,8 @@ RUN adduser respa --home /usr/src/app
 
 WORKDIR /usr/src/app
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
-RUN apt-get update && apt-get install -y gdal-bin postgresql-client gettext nodejs npm
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get update && apt-get install -y gdal-bin postgresql-client gettext nodejs
 
 COPY --chown=respa:respa requirements.txt .
 

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.8-bullseye
 
 ENV APP_NAME respa
 
@@ -8,7 +8,7 @@ RUN adduser respa --home /usr/src/app
 
 WORKDIR /usr/src/app
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update && apt-get install -y gdal-bin postgresql-client gettext nodejs
 
 COPY --chown=respa:respa requirements.txt ./requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ certifi==2022.12.7
     #   sentry-sdk
 cffi==1.15.1
     # via cryptography
-chardet==3.0.4
+charset-normalizer==3.1.0
     # via requests
 click==7.0
     # via pip-tools
@@ -24,7 +24,7 @@ coverage==4.5.2
     # via
     #   -r requirements.in
     #   pytest-cov
-cryptography==40.0.2
+cryptography==41.0.1
     # via requests-ntlm
 daemonize==2.5.0
     # via -r requirements.in
@@ -225,7 +225,7 @@ requests-ntlm==1.1.0
     # via -r requirements.in
 requests-oauthlib==1.2.0
     # via django-allauth
-requests==2.25.1
+requests==2.31.0
     # via
     #   -r requirements.in
     #   django-allauth


### PR DESCRIPTION
And ugprade node to 14.

The bullseye supports olders nodes unlike the base image 3.8 which removed bullseye in favor of bookworm.