### PR TITLE
Use .get with default to get viewpointOrderText in accessibility import

### DIFF
--- a/resources/management/commands/accessibility_import.py
+++ b/resources/management/commands/accessibility_import.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
                 continue
             vp_ids.append(vp_id)
             vp_attributes = {
-                'order_text': viewpoint_data['viewpointOrderText'],
+                'order_text': viewpoint_data.get('viewpointOrderText', '0'),
             }
             enabled_languages = [lang[0] for lang in settings.LANGUAGES]
             for name_translation in viewpoint_data['names']:


### PR DESCRIPTION
Try to fix reported cron issues. The current fix simply applies a default if the value is not found, but this might not be the correct thing to do.